### PR TITLE
Add charts toolbar parameter

### DIFF
--- a/projects/oneteme/jquery-apexcharts/src/lib/component/chart.component.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/component/chart.component.ts
@@ -46,7 +46,6 @@ export class  ChartComponent<X extends XaxisType, Y extends YaxisType> {
     @Input() data: any[];
     @Input() isLoading: boolean;
 
-
     change(event: string) {
         if(!this.initialType) {
             this.initialType = this.type;

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts
@@ -1,25 +1,49 @@
-import { Directive, ElementRef, EventEmitter, Input, OnDestroy, Output, SimpleChanges, inject } from "@angular/core";
-import { ChartProvider, ChartView, XaxisType, buildChart, naturalFieldComparator, mergeDeep } from "@oneteme/jquery-core";
-import ApexCharts from "apexcharts";
-import { customIcons, getType } from "./utils";
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import {
+  ChartProvider,
+  ChartView,
+  XaxisType,
+  buildChart,
+  naturalFieldComparator,
+  mergeDeep,
+} from '@oneteme/jquery-core';
+import ApexCharts from 'apexcharts';
+import { customIcons, getType } from './utils';
 
 @Directive({
   standalone: true,
-  selector: '[bar-chart]'
+  selector: '[bar-chart]',
 })
-export class BarChartDirective<X extends XaxisType> implements ChartView<X, number>, OnDestroy {
+export class BarChartDirective<X extends XaxisType>
+  implements ChartView<X, number>, OnDestroy
+{
   private el: ElementRef = inject(ElementRef);
 
   private _chart: ApexCharts;
-  private _chartConfig: ChartProvider<X, number> = {};
+  private _chartConfig: ChartProvider<X, number> = {
+    showToolbar: false,
+  };
   private _options: any = {
     chart: {
-      type: 'bar'
+      type: 'bar',
     },
-    series: []
+    series: [],
   };
 
-  @Input({ alias: 'type', required: true }) type: 'bar' | 'column' | 'funnel' | 'pyramid';
+  @Input({ alias: 'type', required: true }) type:
+    | 'bar'
+    | 'column'
+    | 'funnel'
+    | 'pyramid';
 
   @Input({ alias: 'config', required: true }) config: ChartProvider<X, number>;
 
@@ -29,87 +53,120 @@ export class BarChartDirective<X extends XaxisType> implements ChartView<X, numb
 
   @Input() isLoading: boolean = false;
 
-  @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> = new EventEmitter();
+  @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
+    new EventEmitter();
 
   updateConfig() {
     let that = this;
     this._chartConfig = this.config;
-    mergeDeep(this._options, {
-      chart: {
-        height: this._chartConfig.height ?? '100%',
-        width: this._chartConfig.width ?? '100%',
-        stacked: this._chartConfig.stacked,
-        toolbar: {
-          show: true,
-          tools: {
-            download: false,
-            selection: false,
-            zoom: false,
-            zoomin: false,
-            zoomout: false,
-            pan: false,
-            reset: false,
-            customIcons: customIcons((arg) => that.customEvent.emit(arg), this.canPivot)
-          }
-        },
-        events: {
-          mouseMove: function (e, c, config) {
-            var toolbar = that.el.nativeElement.querySelector('.apexcharts-toolbar');
-            toolbar ? toolbar.style.visibility = "visible" : null;
+    mergeDeep(
+      this._options,
+      {
+        chart: {
+          height: this._chartConfig.height ?? '100%',
+          width: this._chartConfig.width ?? '100%',
+          stacked: this._chartConfig.stacked,
+          toolbar: {
+            // show: true,
+            show: this._chartConfig.showToolbar ?? false,
+            tools: {
+              download: false,
+              selection: false,
+              zoom: false,
+              zoomin: false,
+              zoomout: false,
+              pan: false,
+              reset: false,
+              customIcons: customIcons(
+                (arg) => that.customEvent.emit(arg),
+                this.canPivot
+              ),
+            },
           },
-          mouseLeave: function (e, c, config) {
-            var toolbar = that.el.nativeElement.querySelector('.apexcharts-toolbar');
-            toolbar ? toolbar.style.visibility = "hidden" : null;
+          events: {
+            mouseMove: function (e, c, config) {
+              var toolbar = that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              );
+              toolbar ? (toolbar.style.visibility = 'visible') : null;
+            },
+            mouseLeave: function (e, c, config) {
+              var toolbar = that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              );
+              toolbar ? (toolbar.style.visibility = 'hidden') : null;
+            },
+          },
+        },
+        title: {
+          text: this._chartConfig.title,
+        },
+        subtitle: {
+          text: this._chartConfig.subtitle,
+        },
+        xaxis: {
+          title: {
+            text: this._chartConfig.xtitle,
+          },
+        },
+        yaxis: {
+          title: {
+            text: this._chartConfig.ytitle,
+          },
+        },
+      },
+      this.type == 'bar'
+        ? {
+            plotOptions: {
+              bar: {
+                horizontal: true,
+              },
+            },
           }
-        }
-      },
-      title: {
-        text: this._chartConfig.title
-      },
-      subtitle: {
-        text: this._chartConfig.subtitle
-      },
-      xaxis: {
-        title: {
-          text: this._chartConfig.xtitle
-        }
-      },
-      yaxis: {
-        title: {
-          text: this._chartConfig.ytitle
-        }
-      }
-    }, this.type == 'bar' ? {
-      plotOptions: {
-        bar: {
-          horizontal: true
-        }
-      }
-    } : {}, this._chartConfig.options);
+        : {},
+      this._chartConfig.options
+    );
   }
 
   updateData() {
     var data = [...this.data];
     if (this.type == 'funnel') {
-      data = data.sort(naturalFieldComparator('asc', this._chartConfig.series[0].data.y));
+      data = data.sort(
+        naturalFieldComparator('asc', this._chartConfig.series[0].data.y)
+      );
     } else if (this.type == 'pyramid') {
-      data = data.sort(naturalFieldComparator('desc', this._chartConfig.series[0].data.y));
+      data = data.sort(
+        naturalFieldComparator('desc', this._chartConfig.series[0].data.y)
+      );
     }
-    var commonChart = buildChart(data, { ...this._chartConfig, pivot: !this.canPivot ? false : this._chartConfig.pivot });
-    mergeDeep(this._options, { series: commonChart.series.map(s => ({ data: s.data, name: s.name, color: s.color, group: s.stack })), xaxis: { type: getType(commonChart), categories: commonChart.categories || [] } });
+    var commonChart = buildChart(data, {
+      ...this._chartConfig,
+      pivot: !this.canPivot ? false : this._chartConfig.pivot,
+    });
+    mergeDeep(this._options, {
+      series: commonChart.series.map((s) => ({
+        data: s.data,
+        name: s.name,
+        color: s.color,
+        group: s.stack,
+      })),
+      xaxis: {
+        type: getType(commonChart),
+        categories: commonChart.categories || [],
+      },
+    });
   }
 
   updateLoading() {
     mergeDeep(this._options, {
       noData: {
-        text: this.isLoading ? 'Loading...' : 'Aucune donnée'
-      }
+        text: this.isLoading ? 'Loading...' : 'Aucune donnée',
+      },
     });
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.type && this.config && this.data) {
-
       if (changes.isLoading) {
         this.updateLoading();
       }
@@ -154,4 +211,3 @@ export class BarChartDirective<X extends XaxisType> implements ChartView<X, numb
     this._chart.render();
   }
 }
-

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts
@@ -53,6 +53,8 @@ export class BarChartDirective<X extends XaxisType>
 
   @Input() isLoading: boolean = false;
 
+  @Input({ required: false }) showToolbar?: boolean;
+
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 
@@ -67,7 +69,6 @@ export class BarChartDirective<X extends XaxisType>
           width: this._chartConfig.width ?? '100%',
           stacked: this._chartConfig.stacked,
           toolbar: {
-            // show: true,
             show: this._chartConfig.showToolbar ?? false,
             tools: {
               download: false,

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts
@@ -53,8 +53,6 @@ export class BarChartDirective<X extends XaxisType>
 
   @Input() isLoading: boolean = false;
 
-  @Input({ required: false }) showToolbar?: boolean;
-
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts
@@ -49,8 +49,6 @@ export class LineChartDirective<X extends XaxisType, Y extends YaxisType>
 
   @Input() isLoading: boolean = false;
 
-  @Input({ required: false }) showToolbar?: boolean;
-
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts
@@ -49,6 +49,8 @@ export class LineChartDirective<X extends XaxisType, Y extends YaxisType>
 
   @Input() isLoading: boolean = false;
 
+  @Input({ required: false }) showToolbar?: boolean;
+
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 
@@ -91,7 +93,6 @@ export class LineChartDirective<X extends XaxisType, Y extends YaxisType>
           width: this._chartConfig.width ?? '100%',
           stacked: this._chartConfig.stacked,
           toolbar: {
-            // show: true,
             show: this._chartConfig.showToolbar ?? false,
             tools: {
               download: false,

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts
@@ -1,150 +1,190 @@
-import { Directive, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, inject } from "@angular/core";
-import { ChartProvider, ChartView, XaxisType, YaxisType, buildChart, mergeDeep } from "@oneteme/jquery-core";
-import ApexCharts from "apexcharts";
-import { customIcons, getType } from "./utils";
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import {
+  ChartProvider,
+  ChartView,
+  XaxisType,
+  YaxisType,
+  buildChart,
+  mergeDeep,
+} from '@oneteme/jquery-core';
+import ApexCharts from 'apexcharts';
+import { customIcons, getType } from './utils';
 
 @Directive({
-    standalone: true,
-    selector: '[line-chart]'
+  standalone: true,
+  selector: '[line-chart]',
 })
-export class LineChartDirective<X extends XaxisType, Y extends YaxisType> implements ChartView<X, Y>, OnChanges, OnDestroy {
-    private el: ElementRef = inject(ElementRef);
+export class LineChartDirective<X extends XaxisType, Y extends YaxisType>
+  implements ChartView<X, Y>, OnChanges, OnDestroy
+{
+  private el: ElementRef = inject(ElementRef);
 
-    private _chart: ApexCharts;
-    private _chartConfig: ChartProvider<X, Y> = {};
+  private _chart: ApexCharts;
+  private _chartConfig: ChartProvider<X, Y> = {
+    showToolbar: false,
+  };
 
-    private _options: any = {
+  private _options: any = {
+    chart: {
+      type: 'line',
+    },
+    series: [],
+  };
+
+  @Input({ required: true }) type: 'line' | 'area';
+
+  @Input({ required: true }) config: ChartProvider<X, Y>;
+
+  @Input({ required: true }) data: any[];
+
+  @Input() isLoading: boolean = false;
+
+  @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
+    new EventEmitter();
+
+  ngOnDestroy(): void {
+    if (this._chart) {
+      this._chart.destroy();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.type && this.config && this.data) {
+      if (changes.type) {
+        this.updateType();
+      }
+      if (changes.isLoading) {
+        this.updateLoading();
+      }
+      if (changes.config) {
+        this.updateConfig();
+      }
+      if (changes.config || changes.data) {
+        this.updateData();
+      }
+      this.updateChart();
+    }
+  }
+
+  updateType() {
+    mergeDeep(this._options, { chart: { type: this.type } });
+  }
+
+  updateConfig() {
+    let that = this;
+    this._chartConfig = this.config;
+    mergeDeep(
+      this._options,
+      {
         chart: {
-            type: 'line'
+          height: this._chartConfig.height ?? '100%',
+          width: this._chartConfig.width ?? '100%',
+          stacked: this._chartConfig.stacked,
+          toolbar: {
+            // show: true,
+            show: this._chartConfig.showToolbar ?? false,
+            tools: {
+              download: false,
+              selection: false,
+              zoom: false,
+              zoomin: false,
+              zoomout: false,
+              pan: false,
+              reset: false,
+              customIcons: customIcons(
+                (arg) => that.customEvent.emit(arg),
+                true
+              ),
+            },
+          },
+          events: {
+            mouseMove: function (e, c, config) {
+              var toolbar = that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              );
+              toolbar ? (toolbar.style.visibility = 'visible') : null;
+            },
+            mouseLeave: function (e, c, config) {
+              var toolbar = that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              );
+              toolbar ? (toolbar.style.visibility = 'hidden') : null;
+            },
+          },
         },
-        series: []
-    };
+        title: {
+          text: this._chartConfig.title,
+        },
+        subtitle: {
+          text: this._chartConfig.subtitle,
+        },
+        xaxis: {
+          title: {
+            text: this._chartConfig.xtitle,
+          },
+        },
+        yaxis: {
+          title: {
+            text: this._chartConfig.ytitle,
+          },
+        },
+      },
+      this._chartConfig.options
+    );
+  }
 
-    @Input({ required: true }) type: 'line' | 'area';
+  updateData() {
+    var commonChart = buildChart(
+      this.data,
+      { ...this._chartConfig, continue: true },
+      null
+    );
+    mergeDeep(this._options, {
+      series: commonChart.series,
+      xaxis: { type: getType(commonChart) },
+    });
+  }
 
-    @Input({ required: true }) config: ChartProvider<X, Y>;
+  updateLoading() {
+    mergeDeep(this._options, {
+      noData: {
+        text: this.isLoading ? 'Loading...' : 'Aucune donnée',
+      },
+    });
+  }
 
-    @Input({ required: true }) data: any[];
-
-    @Input() isLoading: boolean = false;
-
-    @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> = new EventEmitter();
-
-    ngOnDestroy(): void {
-        if (this._chart) {
-            this._chart.destroy();
-        }
+  updateChart() {
+    if (this._chart) {
+      this._chart.destroy();
     }
+    this.createChart();
+    this.render();
+  }
 
-    ngOnChanges(changes: SimpleChanges): void {
-        if (this.type && this.config && this.data) {
-            if (changes.type) {
-                this.updateType();
-            }
-            if (changes.isLoading) {
-                this.updateLoading();
-            }
-            if (changes.config) {
-                this.updateConfig();
-            }
-            if (changes.config || changes.data) {
-                this.updateData();
-            }
-            this.updateChart();
-        }
-    }
+  createChart() {
+    this._chart = new ApexCharts(this.el.nativeElement, this._options);
+  }
 
-    updateType() {
-        mergeDeep(this._options, { chart: { type: this.type } })
-    }
+  // updateOptions() {
+  //     this._chart.resetSeries();
+  //     if (this._options.chart.id) {
+  //         ApexCharts.exec(this._options.chart.id, 'updateOptions', this._options);
+  //     } else {
+  //         this._chart.updateOptions(this._options, false, false);
+  //     }
+  // }
 
-    updateConfig() {
-        let that = this;
-        this._chartConfig = this.config;
-        mergeDeep(this._options, {
-            chart: {
-                height: this._chartConfig.height ?? '100%',
-                width: this._chartConfig.width ?? '100%',
-                stacked: this._chartConfig.stacked,
-                toolbar: {
-                    show: true,
-                    tools: {
-                        download: false,
-                        selection: false,
-                        zoom: false,
-                        zoomin: false,
-                        zoomout: false,
-                        pan: false,
-                        reset: false,
-                        customIcons: customIcons(arg => that.customEvent.emit(arg), true)
-                    }
-                },
-                events: {
-                    mouseMove: function (e, c, config) { 
-                        var toolbar = that.el.nativeElement.querySelector('.apexcharts-toolbar');
-                        toolbar ? toolbar.style.visibility = "visible" : null;
-                    },
-                    mouseLeave: function (e, c, config) { 
-                        var toolbar = that.el.nativeElement.querySelector('.apexcharts-toolbar');
-                        toolbar ? toolbar.style.visibility = "hidden" : null;
-                    }
-                }
-            },
-            title: {
-                text: this._chartConfig.title
-            },
-            subtitle: {
-                text: this._chartConfig.subtitle
-            },
-            xaxis: {
-                title: {
-                    text: this._chartConfig.xtitle
-                }
-            },
-            yaxis: {
-                title: {
-                    text: this._chartConfig.ytitle
-                }
-            }
-        }, this._chartConfig.options);
-    }
-
-    updateData() {
-        var commonChart = buildChart(this.data, {...this._chartConfig, continue: true}, null);
-        mergeDeep(this._options, { series: commonChart.series, xaxis: { type: getType(commonChart) } });
-    }
-
-    updateLoading() {
-        mergeDeep(this._options, {
-            noData: {
-                text: this.isLoading ? 'Loading...' : 'Aucune donnée'
-            }
-        });
-    }
-
-    updateChart() {
-        if (this._chart) {
-            this._chart.destroy();
-        }
-        this.createChart();
-        this.render();
-    }
-
-    createChart() {
-        this._chart = new ApexCharts(this.el.nativeElement, this._options);
-    }
-
-    // updateOptions() {
-    //     this._chart.resetSeries();
-    //     if (this._options.chart.id) {
-    //         ApexCharts.exec(this._options.chart.id, 'updateOptions', this._options);
-    //     } else {
-    //         this._chart.updateOptions(this._options, false, false);
-    //     }
-    // }
-
-    render() {
-        this._chart.render();
-    }
-
+  render() {
+    this._chart.render();
+  }
 }

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts
@@ -61,7 +61,7 @@ export class PieChartDirective
 
   @Input() isLoading: boolean = false;
 
-  @Input({ required: false }) showToolbar?: boolean; // Ajout de cette ligne
+  @Input({ required: false }) showToolbar?: boolean;
 
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts
@@ -1,159 +1,218 @@
-import { Directive, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, inject } from "@angular/core";
-import { ChartProvider, ChartType, ChartView, buildChart, buildSingleSerieChart, mergeDeep } from "@oneteme/jquery-core";
-import { customIcons } from "./utils";
-import ApexCharts from "apexcharts";
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import {
+  ChartProvider,
+  ChartType,
+  ChartView,
+  buildChart,
+  buildSingleSerieChart,
+  mergeDeep,
+} from '@oneteme/jquery-core';
+import { customIcons } from './utils';
+import ApexCharts from 'apexcharts';
 
 @Directive({
-    standalone: true,
-    selector: '[pie-chart]'
+  standalone: true,
+  selector: '[pie-chart]',
 })
-export class PieChartDirective implements ChartView<string, number>, OnChanges, OnDestroy {
-    private el: ElementRef = inject(ElementRef);
+export class PieChartDirective
+  implements ChartView<string, number>, OnChanges, OnDestroy
+{
+  private el: ElementRef = inject(ElementRef);
 
-    private typeMapping: {[key: ChartType]: ChartType} = {
-        'pie': 'pie',
-        'donut': 'donut',
-        'radial': 'radialBar',
-        'polar': 'polarArea',
-        'radar': 'radar'
+  private typeMapping: { [key: ChartType]: ChartType } = {
+    pie: 'pie',
+    donut: 'donut',
+    radial: 'radialBar',
+    polar: 'polarArea',
+    radar: 'radar',
+  };
+
+  private _chart: ApexCharts;
+  private _chartConfig: ChartProvider<string, number> = {
+    showToolbar: false,
+  };
+  private _options: any = {
+    chart: {
+      type: 'pie',
+    },
+    series: [],
+  };
+
+  @Input({ required: true }) type:
+    | 'pie'
+    | 'donut'
+    | 'radialBar'
+    | 'polarArea'
+    | 'radar';
+
+  @Input({ required: true }) config: ChartProvider<string, number>;
+
+  @Input({ required: true }) data: any[];
+
+  @Input() isLoading: boolean = false;
+
+  @Input({ required: false }) showToolbar?: boolean; // Ajout de cette ligne
+
+  @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
+    new EventEmitter();
+
+  ngOnDestroy(): void {
+    if (this._chart) {
+      this._chart.destroy();
     }
+  }
 
-    private _chart: ApexCharts;
-    private _chartConfig: ChartProvider<string, number> = {};
-    private _options: any = {
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.type && this.config && this.data) {
+      if (changes.type) {
+        this.updateType();
+      }
+      if (changes.isLoading) {
+        this.updateLoading();
+      }
+      if (changes.config) {
+        this.updateConfig();
+      }
+      if (changes.config || changes.data) {
+        this.updateData();
+      }
+      this.updateChart();
+    }
+  }
+
+  updateType() {
+    mergeDeep(this._options, { chart: { type: this.typeMapping[this.type] } });
+  }
+
+  updateConfig() {
+    let that = this;
+    this._chartConfig = this.config;
+    mergeDeep(
+      this._options,
+      {
         chart: {
-            type: 'pie'
+          height: this._chartConfig.height ?? '100%',
+          width: this._chartConfig.width ?? '100%',
+          toolbar: {
+            show: this._chartConfig.showToolbar ?? false,
+            tools: {
+              download: false,
+              selection: false,
+              zoom: false,
+              zoomin: false,
+              zoomout: false,
+              pan: false,
+              reset: false,
+              customIcons: customIcons(
+                (arg) => that.customEvent.emit(arg),
+                true
+              ),
+            },
+          },
+          events: {
+            mouseMove: function (e, c, config) {
+              var toolbar = that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              );
+              toolbar ? (toolbar.style.visibility = 'visible') : null;
+            },
+            mouseLeave: function (e, c, config) {
+              var toolbar = that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              );
+              toolbar ? (toolbar.style.visibility = 'hidden') : null;
+            },
+          },
         },
-        series: []
-    };
+        title: {
+          text: this._chartConfig.title,
+        },
+        subtitle: {
+          text: this._chartConfig.subtitle,
+        },
+        xaxis: {
+          title: {
+            text: this._chartConfig.xtitle,
+          },
+        },
+        yaxis: {
+          title: {
+            text: this._chartConfig.ytitle,
+          },
+        },
+      },
+      this._chartConfig.options
+    );
+  }
 
-    @Input({ required: true }) type: 'pie' | 'donut' | 'radialBar' | 'polarArea' | 'radar';
+  updateData() {
+    var chartConfig = { ...this._chartConfig, continue: false };
+    var commonChart =
+      this.data.length != 1 && this.type == 'radar'
+        ? buildChart(this.data, chartConfig, null)
+        : buildSingleSerieChart(this.data, chartConfig, null);
+    var colors = commonChart.series
+      .filter((d) => d.color)
+      .map((d) => <string>d.color);
+    mergeDeep(this._options, {
+      series:
+        this.data.length != 1 && this.type == 'radar'
+          ? commonChart.series
+          : this.type == 'radar'
+          ? [
+              {
+                name: 'Series 1',
+                data: commonChart.series.flatMap((s) =>
+                  s.data.filter((d) => d != null)
+                ),
+              },
+            ]
+          : commonChart.series.flatMap((s) => s.data.filter((d) => d != null)),
+      labels: commonChart.categories || [],
+      colors: colors || [],
+    });
+  }
 
-    @Input({ required: true }) config: ChartProvider<string, number>;
+  updateLoading() {
+    mergeDeep(this._options, {
+      noData: {
+        text: this.isLoading ? 'Loading...' : 'Aucune donnée',
+      },
+    });
+  }
 
-    @Input({ required: true }) data: any[];
-
-    @Input() isLoading: boolean = false;
-
-    @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> = new EventEmitter();
-
-    ngOnDestroy(): void {
-        if (this._chart) {
-            this._chart.destroy();
-        }
+  updateChart() {
+    if (this._chart) {
+      this._chart.destroy();
     }
+    this.createChart();
+    this.render();
+  }
 
-    ngOnChanges(changes: SimpleChanges): void {
-        if (this.type && this.config && this.data) {
-            if (changes.type) {
-                this.updateType();
-            }
-            if (changes.isLoading) {
-                this.updateLoading();
-            }
-            if (changes.config) {
-                this.updateConfig();
-            }
-            if (changes.config || changes.data) {
-                this.updateData();
-            }
-            this.updateChart();
-        }
-    }
+  createChart() {
+    this._chart = new ApexCharts(this.el.nativeElement, this._options);
+  }
 
-    updateType() {
-        mergeDeep(this._options, { chart: { type: this.typeMapping[this.type] } })
-    }
+  // updateOptions() {
+  //     this._chart.resetSeries();
+  //     if (this._options.chart.id) {
+  //         ApexCharts.exec(this._options.chart.id, 'updateOptions', this._options);
+  //     } else {
+  //         this._chart.updateOptions(this._options, false, false);
+  //     }
+  // }
 
-    updateConfig() {
-        let that = this;
-        this._chartConfig = this.config;
-        mergeDeep(this._options, {
-            chart: {
-                height: this._chartConfig.height ?? '100%',
-                width: this._chartConfig.width ?? '100%',
-                toolbar: {
-                    show: true,
-                    tools: {
-                        download: false,
-                        selection: false,
-                        zoom: false,
-                        zoomin: false,
-                        zoomout: false,
-                        pan: false,
-                        reset: false,
-                        customIcons: customIcons(arg => that.customEvent.emit(arg), true)
-                    }
-                },
-                events: {
-                    mouseMove: function (e, c, config) { 
-                        var toolbar = that.el.nativeElement.querySelector('.apexcharts-toolbar');
-                        toolbar ? toolbar.style.visibility = "visible" : null;
-                    },
-                    mouseLeave: function (e, c, config) { 
-                        var toolbar = that.el.nativeElement.querySelector('.apexcharts-toolbar');
-                        toolbar ? toolbar.style.visibility = "hidden" : null;
-                    }
-                }
-            },
-            title: {
-                text: this._chartConfig.title
-            },
-            subtitle: {
-                text: this._chartConfig.subtitle
-            },
-            xaxis: {
-                title: {
-                    text: this._chartConfig.xtitle
-                }
-            },
-            yaxis: {
-                title: {
-                    text: this._chartConfig.ytitle
-                }
-            },
-
-        }, this._chartConfig.options);
-    }
-
-    updateData() {
-        
-        var chartConfig = { ...this._chartConfig, continue: false };
-        var commonChart = this.data.length != 1 && this.type == 'radar' ? buildChart(this.data, chartConfig, null) : buildSingleSerieChart(this.data, chartConfig, null);
-        var colors = commonChart.series.filter(d => d.color).map(d => <string>d.color);
-        mergeDeep(this._options, { series: this.data.length != 1 && this.type == 'radar' ? commonChart.series : this.type == 'radar' ? [{ name: 'Series 1', data: commonChart.series.flatMap(s => s.data.filter(d => d != null))}] : commonChart.series.flatMap(s => s.data.filter(d => d != null)), labels: commonChart.categories || [], colors: colors || [] });
-    }
-
-    updateLoading() {
-        mergeDeep(this._options, {
-            noData: {
-                text: this.isLoading ? 'Loading...' : 'Aucune donnée'
-            }
-        });
-    }
-
-    updateChart() {
-        if (this._chart) {
-            this._chart.destroy();
-        }
-        this.createChart();
-        this.render();
-    }
-
-    createChart() {
-        this._chart = new ApexCharts(this.el.nativeElement, this._options);
-    }
-
-    // updateOptions() {
-    //     this._chart.resetSeries();
-    //     if (this._options.chart.id) {
-    //         ApexCharts.exec(this._options.chart.id, 'updateOptions', this._options);
-    //     } else {
-    //         this._chart.updateOptions(this._options, false, false);
-    //     }
-    // }
-
-    render() {
-        this._chart.render();
-    }
+  render() {
+    this._chart.render();
+  }
 }

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts
@@ -61,8 +61,6 @@ export class PieChartDirective
 
   @Input() isLoading: boolean = false;
 
-  @Input({ required: false }) showToolbar?: boolean;
-
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts
@@ -1,143 +1,195 @@
-import { Directive, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, inject } from "@angular/core";
-import { ChartProvider, ChartView, XaxisType, buildChart, mergeDeep } from "@oneteme/jquery-core";
-import { customIcons, getType } from "./utils";
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import {
+  ChartProvider,
+  ChartView,
+  XaxisType,
+  buildChart,
+  mergeDeep,
+} from '@oneteme/jquery-core';
+import { customIcons, getType } from './utils';
 
-import ApexCharts from "apexcharts";
+import ApexCharts from 'apexcharts';
 
 @Directive({
-    standalone: true,
-    selector: '[range-chart]'
+  standalone: true,
+  selector: '[range-chart]',
 })
-export class RangeChartDirective<X extends XaxisType> implements ChartView<X, number[]>, OnChanges, OnDestroy {
-    private el: ElementRef = inject(ElementRef);
+export class RangeChartDirective<X extends XaxisType>
+  implements ChartView<X, number[]>, OnChanges, OnDestroy
+{
+  private el: ElementRef = inject(ElementRef);
 
-    private _chart: ApexCharts;
-    private _chartConfig: ChartProvider<X, number[]> = {};
+  private _chart: ApexCharts;
+  private _chartConfig: ChartProvider<X, number[]> = {
+    showToolbar: false,
+  };
 
-    private _options: any = {
+  private _options: any = {
+    chart: {
+      type: 'rangeArea',
+    },
+    series: [],
+  };
+
+  @Input({ required: true }) type: 'rangeArea' | 'rangeBar' | 'rangeColumn';
+
+  @Input({ required: true }) config: ChartProvider<X, number[]>;
+
+  @Input({ required: true }) data: any[];
+
+  @Input() canPivot: boolean = true;
+
+  @Input() isLoading: boolean = false;
+
+  @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
+    new EventEmitter();
+
+  ngOnDestroy(): void {
+    if (this._chart) {
+      this._chart.destroy();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.type && this.config && this.data) {
+      if (changes.type) {
+        this.updateType();
+      }
+      if (changes.isLoading) {
+        this.updateLoading();
+      }
+      if (changes.config) {
+        this.updateConfig();
+      }
+      if (changes.config || changes.data) {
+        this.updateData();
+      }
+      this.updateChart();
+    }
+  }
+
+  updateType() {
+    mergeDeep(this._options, {
+      chart: { type: this.type == 'rangeColumn' ? 'rangeBar' : this.type },
+    });
+  }
+
+  updateConfig() {
+    let that = this;
+    this._chartConfig = this.config;
+    mergeDeep(
+      this._options,
+      {
         chart: {
-            type: 'rangeArea'
+          height: this._chartConfig.height ?? '100%',
+          width: this._chartConfig.width ?? '100%',
+          toolbar: {
+            //   show: true,
+            show: this._chartConfig.showToolbar ?? false,
+              tools: {
+              download: false,
+              selection: false,
+              zoom: false,
+              zoomin: false,
+              zoomout: false,
+              pan: false,
+              reset: false,
+              customIcons: customIcons(
+                (arg) => that.customEvent.emit(arg),
+                true
+              ),
+            },
+          },
+          events: {
+            mouseMove: function (e, c, config) {
+              that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              ).style.visibility = 'visible';
+            },
+            mouseLeave: function (e, c, config) {
+              that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              ).style.visibility = 'hidden';
+            },
+          },
         },
-        series: []
-    };
-
-    @Input({ required: true }) type: 'rangeArea' | 'rangeBar' | 'rangeColumn';
-
-    @Input({ required: true }) config: ChartProvider<X, number[]>;
-
-    @Input({ required: true }) data: any[];
-
-    @Input() canPivot: boolean = true;
-
-    @Input() isLoading: boolean = false;
-
-    @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> = new EventEmitter();
-
-    ngOnDestroy(): void {
-        if (this._chart) {
-            this._chart.destroy();
-        }
-    }
-
-    ngOnChanges(changes: SimpleChanges): void {
-        if (this.type && this.config && this.data) {
-            if (changes.type) {
-                this.updateType();
-            }
-            if (changes.isLoading) {
-                this.updateLoading();
-            }
-            if (changes.config) {
-                this.updateConfig();
-            }
-            if (changes.config || changes.data) {
-                this.updateData();
-            }
-            this.updateChart();
-        }
-    }
-
-    updateType() {
-        mergeDeep(this._options, { chart: { type: this.type == 'rangeColumn' ? 'rangeBar' : this.type } })
-    }
-
-    updateConfig() {
-        let that = this;
-        this._chartConfig = this.config;
-        mergeDeep(this._options, {
-            chart: {
-                height: this._chartConfig.height ?? '100%',
-                width: this._chartConfig.width ?? '100%',
-                toolbar: {
-                    show: true,
-                    tools: {
-                        download: false,
-                        selection: false,
-                        zoom: false,
-                        zoomin: false,
-                        zoomout: false,
-                        pan: false,
-                        reset: false,
-                        customIcons: customIcons(arg => that.customEvent.emit(arg), true)
-                    }
-                },
-                events: {
-                    mouseMove: function (e, c, config) { that.el.nativeElement.querySelector('.apexcharts-toolbar').style.visibility = "visible" },
-                    mouseLeave: function (e, c, config) { that.el.nativeElement.querySelector('.apexcharts-toolbar').style.visibility = "hidden" }
-                }
-            },
-            title: {
-                text: this._chartConfig.title
-            },
-            subtitle: {
-                text: this._chartConfig.subtitle
-            },
-            xaxis: {
-                title: {
-                    text: this._chartConfig.xtitle
-                }
-            },
-            yaxis: {
-                title: {
-                    text: this._chartConfig.ytitle
-                }
-            }
-        }, this.type == 'rangeBar' ? {
+        title: {
+          text: this._chartConfig.title,
+        },
+        subtitle: {
+          text: this._chartConfig.subtitle,
+        },
+        xaxis: {
+          title: {
+            text: this._chartConfig.xtitle,
+          },
+        },
+        yaxis: {
+          title: {
+            text: this._chartConfig.ytitle,
+          },
+        },
+      },
+      this.type == 'rangeBar'
+        ? {
             plotOptions: {
-                bar: {
-                    horizontal: true
-                }
-            }
-        } : {}, this._chartConfig.options);
-    }
+              bar: {
+                horizontal: true,
+              },
+            },
+          }
+        : {},
+      this._chartConfig.options
+    );
+  }
 
-    updateData() {
-        var commonChart = buildChart(this.data, { ...this._chartConfig, continue: true, pivot: !this.canPivot ? false: this._chartConfig.pivot }, null);
-        mergeDeep(this._options, { series: commonChart.series, xaxis: { type: getType(commonChart) } });
-    }
+  updateData() {
+    var commonChart = buildChart(
+      this.data,
+      {
+        ...this._chartConfig,
+        continue: true,
+        pivot: !this.canPivot ? false : this._chartConfig.pivot,
+      },
+      null
+    );
+    mergeDeep(this._options, {
+      series: commonChart.series,
+      xaxis: { type: getType(commonChart) },
+    });
+  }
 
-    updateLoading() {
-        mergeDeep(this._options, {
-            noData: {
-                text: this.isLoading ? 'Loading...' : 'Aucune donnée'
-            }
-        });
-    }
+  updateLoading() {
+    mergeDeep(this._options, {
+      noData: {
+        text: this.isLoading ? 'Loading...' : 'Aucune donnée',
+      },
+    });
+  }
 
-    updateChart() {
-        if (this._chart) {
-            this._chart.destroy();
-        }
-        this.createChart();
-        this.render();
+  updateChart() {
+    if (this._chart) {
+      this._chart.destroy();
     }
+    this.createChart();
+    this.render();
+  }
 
-    createChart() {
-        this._chart = new ApexCharts(this.el.nativeElement, this._options);
-    }
+  createChart() {
+    this._chart = new ApexCharts(this.el.nativeElement, this._options);
+  }
 
-    render() {
-        this._chart.render();
-    }
-
+  render() {
+    this._chart.render();
+  }
 }

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts
@@ -51,6 +51,8 @@ export class RangeChartDirective<X extends XaxisType>
 
   @Input() isLoading: boolean = false;
 
+  @Input({ required: false }) showToolbar?: boolean;
+
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 
@@ -94,7 +96,6 @@ export class RangeChartDirective<X extends XaxisType>
           height: this._chartConfig.height ?? '100%',
           width: this._chartConfig.width ?? '100%',
           toolbar: {
-            //   show: true,
             show: this._chartConfig.showToolbar ?? false,
               tools: {
               download: false,

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts
@@ -51,8 +51,6 @@ export class RangeChartDirective<X extends XaxisType>
 
   @Input() isLoading: boolean = false;
 
-  @Input({ required: false }) showToolbar?: boolean;
-
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/test-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/test-chart.directive.ts
@@ -1,50 +1,68 @@
-import { Directive, ElementRef, inject } from "@angular/core";
-import ApexCharts from "apexcharts";
+import { Directive, ElementRef, inject } from '@angular/core';
+import ApexCharts from 'apexcharts';
 @Directive({
-    standalone: true,
-    selector: '[test-chart]'
+  standalone: true,
+  selector: '[test-chart]',
 })
 export class TestChartDirective {
-    private el: ElementRef = inject(ElementRef);
+  private el: ElementRef = inject(ElementRef);
 
-    private _chart: ApexCharts;
+  private _chart: ApexCharts;
 
-    ngAfterViewInit() {
-        var options = {
-            series: [{
-                name: 'Website Blog',
-                type: 'column',
-                data: [440, 505, 414, 671, 227, 413, 201, 352, 752, 320, 257, 160]
-            }, {
-                name: 'Social Media',
-                type: 'area',
-                data: [23, 42, 35, 27, 43, 22, 17, 31, 22, 22, 12, 16]
-            }],
-            chart: {
-                height: 350,
-                type: 'area',
-            },
-            dataLabels: {
-                enabled: true,
-                enabledOnSeries: [1]
-            },
-            labels: ['01 Jan 2001', '02 Jan 2001', '03 Jan 2001', '04 Jan 2001', '05 Jan 2001', '06 Jan 2001', '07 Jan 2001', '08 Jan 2001', '09 Jan 2001', '10 Jan 2001', '11 Jan 2001', '12 Jan 2001'],
-            xaxis: {
-                type: 'datetime'
-            },
-            yaxis: [{
-                title: {
-                    text: 'Website Blog',
-                },
-
-            }, {
-                opposite: true,
-                title: {
-                    text: 'Social Media'
-                }
-            }]
-        };
-        this._chart = new ApexCharts(this.el.nativeElement, options);
-        this._chart.render();
-    }
+  ngAfterViewInit() {
+    var options = {
+      series: [
+        {
+          name: 'Website Blog',
+          type: 'column',
+          data: [440, 505, 414, 671, 227, 413, 201, 352, 752, 320, 257, 160],
+        },
+        {
+          name: 'Social Media',
+          type: 'area',
+          data: [23, 42, 35, 27, 43, 22, 17, 31, 22, 22, 12, 16],
+        },
+      ],
+      chart: {
+        height: 350,
+        type: 'area',
+      },
+      dataLabels: {
+        enabled: true,
+        enabledOnSeries: [1],
+      },
+      labels: [
+        '01 Jan 2001',
+        '02 Jan 2001',
+        '03 Jan 2001',
+        '04 Jan 2001',
+        '05 Jan 2001',
+        '06 Jan 2001',
+        '07 Jan 2001',
+        '08 Jan 2001',
+        '09 Jan 2001',
+        '10 Jan 2001',
+        '11 Jan 2001',
+        '12 Jan 2001',
+      ],
+      xaxis: {
+        type: 'datetime',
+      },
+      yaxis: [
+        {
+          title: {
+            text: 'Website Blog',
+          },
+        },
+        {
+          opposite: true,
+          title: {
+            text: 'Social Media',
+          },
+        },
+      ],
+    };
+    this._chart = new ApexCharts(this.el.nativeElement, options);
+    this._chart.render();
+  }
 }

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts
@@ -47,8 +47,6 @@ export class TreemapChartDirective
 
   @Input() isLoading: boolean = false;
 
-  @Input({ required: false }) showToolbar?: boolean;
-
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts
@@ -47,6 +47,8 @@ export class TreemapChartDirective
 
   @Input() isLoading: boolean = false;
 
+  @Input({ required: false }) showToolbar?: boolean;
+
   @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
     new EventEmitter();
 
@@ -88,7 +90,6 @@ export class TreemapChartDirective
           height: this._chartConfig.height ?? '100%',
           width: this._chartConfig.width ?? '100%',
           toolbar: {
-            // show: true,
             show: this._chartConfig.showToolbar ?? false,
             tools: {
               download: false,

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts
@@ -1,133 +1,176 @@
-import { Directive, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, inject } from "@angular/core";
-import { ChartProvider, ChartView, buildChart, mergeDeep } from "@oneteme/jquery-core";
-import { customIcons, getType } from "./utils";
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import {
+  ChartProvider,
+  ChartView,
+  buildChart,
+  mergeDeep,
+} from '@oneteme/jquery-core';
+import { customIcons, getType } from './utils';
 
-import ApexCharts from "apexcharts";
+import ApexCharts from 'apexcharts';
 
 @Directive({
-    standalone: true,
-    selector: '[treemap-chart]'
+  standalone: true,
+  selector: '[treemap-chart]',
 })
-export class TreemapChartDirective implements ChartView<string, number>, OnChanges, OnDestroy {
-    private el: ElementRef = inject(ElementRef);
+export class TreemapChartDirective
+  implements ChartView<string, number>, OnChanges, OnDestroy
+{
+  private el: ElementRef = inject(ElementRef);
 
-    private _chart: ApexCharts;
-    private _chartConfig: ChartProvider<string, number> = {};
-    private _options: any = {
+  private _chart: ApexCharts;
+  private _chartConfig: ChartProvider<string, number> = {
+    showToolbar: false,
+  };
+  private _options: any = {
+    chart: {
+      type: 'treemap',
+    },
+    series: [],
+  };
+
+  @Input({ required: true }) type: 'treemap' | 'heatmap';
+
+  @Input({ required: true }) config: ChartProvider<string, number>;
+
+  @Input({ required: true }) data: any[];
+
+  @Input() isLoading: boolean = false;
+
+  @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> =
+    new EventEmitter();
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.type && this.config && this.data) {
+      if (changes.type) {
+        this.updateType();
+      }
+      if (changes.isLoading) {
+        this.updateLoading();
+      }
+      if (changes.config) {
+        this.updateConfig();
+      }
+      if (changes.config || changes.data) {
+        this.updateData();
+      }
+      this.updateChart();
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this._chart) {
+      this._chart.destroy();
+    }
+  }
+
+  updateType() {
+    mergeDeep(this._options, { chart: { type: this.type } });
+  }
+
+  updateConfig() {
+    let that = this;
+    this._chartConfig = this.config;
+    mergeDeep(
+      this._options,
+      {
         chart: {
-            type: 'treemap'
+          height: this._chartConfig.height ?? '100%',
+          width: this._chartConfig.width ?? '100%',
+          toolbar: {
+            // show: true,
+            show: this._chartConfig.showToolbar ?? false,
+            tools: {
+              download: false,
+              selection: false,
+              zoom: false,
+              zoomin: false,
+              zoomout: false,
+              pan: false,
+              reset: false,
+              customIcons: customIcons(
+                (arg) => that.customEvent.emit(arg),
+                true
+              ),
+            },
+          },
+          events: {
+            mouseMove: function (e, c, config) {
+              that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              ).style.visibility = 'visible';
+            },
+            mouseLeave: function (e, c, config) {
+              that.el.nativeElement.querySelector(
+                '.apexcharts-toolbar'
+              ).style.visibility = 'hidden';
+            },
+          },
         },
-        series: []
-    };
+        title: {
+          text: this._chartConfig.title,
+        },
+        subtitle: {
+          text: this._chartConfig.subtitle,
+        },
+        xaxis: {
+          title: {
+            text: this._chartConfig.xtitle,
+          },
+        },
+        yaxis: {
+          title: {
+            text: this._chartConfig.ytitle,
+          },
+        },
+      },
+      this._chartConfig.options
+    );
+  }
 
-    @Input({ required: true }) type: 'treemap' | 'heatmap';
+  updateData() {
+    var commonChart = buildChart(
+      this.data,
+      { ...this._chartConfig, continue: true },
+      null
+    );
+    mergeDeep(this._options, {
+      series: commonChart.series,
+      xaxis: { type: getType(commonChart) },
+    });
+  }
 
-    @Input({ required: true }) config: ChartProvider<string, number>;
+  updateLoading() {
+    mergeDeep(this._options, {
+      noData: {
+        text: this.isLoading ? 'Loading...' : 'Aucune donnée',
+      },
+    });
+  }
 
-    @Input({ required: true }) data: any[];
-
-    @Input() isLoading: boolean = false;
-
-    @Output() customEvent: EventEmitter<'previous' | 'next' | 'pivot'> = new EventEmitter();
-
-    ngOnChanges(changes: SimpleChanges): void {
-        if (this.type && this.config && this.data) {
-            if (changes.type) {
-                this.updateType();
-            }
-            if (changes.isLoading) {
-                this.updateLoading();
-            }
-            if (changes.config) {
-                this.updateConfig();
-            }
-            if (changes.config || changes.data) {
-                this.updateData();
-            }
-            this.updateChart();
-        }
+  updateChart() {
+    if (this._chart) {
+      this._chart.destroy();
     }
+    this.createChart();
+    this.render();
+  }
 
-    ngOnDestroy(): void {
-        if (this._chart) {
-            this._chart.destroy();
-        }
-    }
+  createChart() {
+    this._chart = new ApexCharts(this.el.nativeElement, this._options);
+  }
 
-    updateType() {
-        mergeDeep(this._options, { chart: { type: this.type } })
-    }
-
-    updateConfig() {
-        let that = this;
-        this._chartConfig = this.config;
-        mergeDeep(this._options, {
-            chart: {
-                height: this._chartConfig.height ?? '100%',
-                width: this._chartConfig.width ?? '100%',
-                toolbar: {
-                    show: true,
-                    tools: {
-                        download: false,
-                        selection: false,
-                        zoom: false,
-                        zoomin: false,
-                        zoomout: false,
-                        pan: false,
-                        reset: false,
-                        customIcons: customIcons(arg => that.customEvent.emit(arg), true)
-                    }
-                },
-                events: {
-                    mouseMove: function(e, c, config) { that.el.nativeElement.querySelector('.apexcharts-toolbar').style.visibility="visible" },
-                    mouseLeave: function(e, c, config) { that.el.nativeElement.querySelector('.apexcharts-toolbar').style.visibility="hidden" }
-                }
-            },
-            title: {
-                text: this._chartConfig.title
-            },
-            subtitle: {
-                text: this._chartConfig.subtitle
-            },
-            xaxis: {
-                title: {
-                    text: this._chartConfig.xtitle
-                }
-            },
-            yaxis: {
-                title: {
-                    text: this._chartConfig.ytitle
-                }
-            }
-        }, this._chartConfig.options);
-    }
-
-    updateData() {
-        var commonChart = buildChart(this.data, { ...this._chartConfig, continue: true }, null);
-        mergeDeep(this._options, { series: commonChart.series, xaxis: { type: getType(commonChart) } });        
-    }
-
-    updateLoading() {
-        mergeDeep(this._options, {
-            noData: {
-                text: this.isLoading ? 'Loading...' : 'Aucune donnée'
-            }
-        });
-    }
-
-    updateChart() {
-        if (this._chart) {
-            this._chart.destroy();
-        }
-        this.createChart();
-        this.render();
-    }
-
-    createChart() {
-        this._chart = new ApexCharts(this.el.nativeElement, this._options);
-    }
-
-    render() {
-        this._chart.render();
-    }
+  render() {
+    this._chart.render();
+  }
 }

--- a/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
+++ b/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
@@ -121,7 +121,13 @@ export function buildChart<X extends XaxisType, Y extends YaxisType>(objects: an
 function newChart<X extends XaxisType, Y extends YaxisType>(provider: ChartProvider<X,Y>) : CommonChart<X,Y>{
     return Object.entries(provider)
     .filter(e=> ['series'].indexOf(e[0])<0)
-    .reduce((acc,e)=>{acc[e[0]] = e[1]; return acc;}, {series:[]})
+    .reduce((acc,e)=>{
+        acc[e[0]] = e[1]; 
+        return acc;
+    }, {
+        series:[],
+        showToolbar: provider.showToolbar
+    })
 }
 
 function resolveDataProvider<T>(provider?: T | DataProvider<T>, defaultValue?: T): DataProvider<T> {
@@ -164,6 +170,7 @@ export interface ChartProvider<X extends XaxisType, Y extends YaxisType> { //rm 
     xorder?: Sort;
     series?: SerieProvider<X,Y>[];
     options?: any;
+    showToolbar?: boolean; 
 }
 
 export interface SerieProvider<X extends XaxisType, Y extends YaxisType> { //rm SerieProvider
@@ -201,6 +208,7 @@ export interface CommonChart<X extends XaxisType, Y extends YaxisType | Coordina
     stacked?: boolean;
     xorder?: Sort;
     options?: any;
+    showToolbar?: boolean; // Le ? est également important ici
 }
 
 export interface CommonSerie<Y extends YaxisType | Coordinate2D> {
@@ -248,4 +256,5 @@ export interface ChartView<X extends XaxisType, Y extends YaxisType> {
     data: any[];
     isLoading: boolean;
     canPivot?: boolean;
+    showToolbar?: boolean;
 }

--- a/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
+++ b/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
@@ -256,5 +256,4 @@ export interface ChartView<X extends XaxisType, Y extends YaxisType> {
     data: any[];
     isLoading: boolean;
     canPivot?: boolean;
-    showToolbar?: boolean;
 }

--- a/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
+++ b/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
@@ -170,7 +170,7 @@ export interface ChartProvider<X extends XaxisType, Y extends YaxisType> { //rm 
     xorder?: Sort;
     series?: SerieProvider<X,Y>[];
     options?: any;
-    showToolbar?: boolean; 
+    showToolbar?: boolean;
 }
 
 export interface SerieProvider<X extends XaxisType, Y extends YaxisType> { //rm SerieProvider

--- a/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
+++ b/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
@@ -208,7 +208,7 @@ export interface CommonChart<X extends XaxisType, Y extends YaxisType | Coordina
     stacked?: boolean;
     xorder?: Sort;
     options?: any;
-    showToolbar?: boolean; // Le ? est également important ici
+    showToolbar?: boolean;
 }
 
 export interface CommonSerie<Y extends YaxisType | Coordinate2D> {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,50 +1,85 @@
 import { Component } from '@angular/core';
-import { ChartProvider, XaxisType, YaxisType, buildChart, combineFields, field, joinFields, rangeFields, values } from '@oneteme/jquery-core';
+import {
+  ChartProvider,
+  XaxisType,
+  YaxisType,
+  buildChart,
+  combineFields,
+  field,
+  joinFields,
+  rangeFields,
+  values,
+} from '@oneteme/jquery-core';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
-  pieExample: { data: any[], config: ChartProvider<string, number> } = {
-    data: [
-      { count_2xx: 110, count_4xx: 160, count_5xx: 80 }
-    ],
+  pieExample: { data: any[]; config: ChartProvider<string, number> } = {
+    data: [{ count_2xx: 110, count_4xx: 160, count_5xx: 80 }],
     config: {
+
+      // Permettait de désactiver la toolbar pour un graph (avant c'etait par défaut à true dans les directives : show: true)
+
+      // options: {
+      //   chart: {
+      //     toolbar: { show: false },
+      //   },
+      // },
+
+      // methode simplifiée ajouter la toolbar ou non (par défaut à false comme demandé dans le fix mais voir avec Youssef. Dans les directives, si une valeur par defaut est indiquée pour showToolbar, alors show prend cette valeur sinon false)
+      showToolbar: true,
+
       series: [
-        { data: { x: values('2xx'), y: field('count_2xx') }, name: 'Mapper 1', color: '#2E93fA' },
-        { data: { x: values('4xx'), y: field('count_4xx') }, name: 'Mapper 2', color: '#66DA26' },
-        { data: { x: values('5xx'), y: field('count_5xx') }, name: 'Mapper 3', color: '#546E7A' }
-      ]
-    }
+        {
+          data: { x: values('2xx'), y: field('count_2xx') },
+          name: 'Mapper 1',
+          color: '#2E93fA',
+        },
+        {
+          data: { x: values('4xx'), y: field('count_4xx') },
+          name: 'Mapper 2',
+          color: '#66DA26',
+        },
+        {
+          data: { x: values('5xx'), y: field('count_5xx') },
+          name: 'Mapper 3',
+          color: '#546E7A',
+        },
+      ],
+    },
   };
 
-  pieExample2: { data: any[], config: ChartProvider<string, number> } = {
+  pieExample2: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 110, field: '2xx' },
       { count: 160, field: '4xx' },
-      { count: 80, field: '5xx' }
+      { count: 80, field: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: 'Nombre d\'appels' }
-      ]
-    }
+        {
+          data: { x: field('field'), y: field('count') },
+          name: "Nombre d'appels",
+        },
+      ],
+    },
   };
 
-  pieExample3: { data: any[], config: ChartProvider<string, number> } = {
+  pieExample3: { data: any[]; config: ChartProvider<string, number> } = {
     data: [],
     config: {
       series: [
         { data: { x: values('2xx'), y: values(110) } },
         { data: { x: values('4xx'), y: values(160) } },
-        { data: { x: values('5xx'), y: values(80) } }
-      ]
-    }
+        { data: { x: values('5xx'), y: values(80) } },
+      ],
+    },
   };
 
-  pieExample4: { data: any[], config: ChartProvider<string, number> } = {
+  pieExample4: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 80, field: 'Api 1', subField: '2xx' },
       { count: 20, field: 'Api 2', subField: '2xx' },
@@ -54,16 +89,18 @@ export class AppComponent {
       { count: 50, field: 'Api 3', subField: '4xx' },
       { count: 10, field: 'Api 1', subField: '5xx' },
       { count: 20, field: 'Api 2', subField: '5xx' },
-      { count: 50, field: 'Api 3', subField: '5xx' }
+      { count: 50, field: 'Api 3', subField: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: joinFields('_', 'field', 'subField'), y: field('count') } }
-      ]
-    }
+        {
+          data: { x: joinFields('_', 'field', 'subField'), y: field('count') },
+        },
+      ],
+    },
   };
 
-  pieExample5: { data: any[], config: ChartProvider<string, number> } = {
+  pieExample5: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 80, field: 'Api 1', subField: '2xx' },
       { count: 20, field: 'Api 2', subField: '2xx' },
@@ -73,121 +110,132 @@ export class AppComponent {
       { count: 50, field: 'Api 3', subField: '4xx' },
       { count: 10, field: 'Api 1', subField: '5xx' },
       { count: 20, field: 'Api 2', subField: '5xx' },
-      { count: 50, field: 'Api 3', subField: '5xx' }
+      { count: 50, field: 'Api 3', subField: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: field('subField') }
-      ]
-    }
+        {
+          data: { x: field('field'), y: field('count') },
+          name: field('subField'),
+        },
+      ],
+    },
   };
 
-  pieExample6: { data: any[], config: ChartProvider<string, number> } = {
+  pieExample6: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
-      ]
-    }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
+      ],
+    },
   };
 
-  pieExample7: { data: any[], config: ChartProvider<string, number> } = {
+  pieExample7: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
-      xorder: 'asc'
-    }
+      xorder: 'asc',
+    },
   };
 
-  pieExample8: { data: any[], config: ChartProvider<string, number> } = {
+  pieExample8: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
-      xorder: 'desc'
-    }
+      xorder: 'desc',
+    },
   };
 
-  pieExample9: { data: any[], config: ChartProvider<string, number> } = {
+  pieExample9: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
-      continue: true
-    }
+      continue: true,
+    },
   };
 
-
-
-  barExample: { data: any[], config: ChartProvider<string, number> } = {
-    data: [
-      { count_2xx: 110, count_4xx: 160, count_5xx: 80 }
-    ],
+  barExample: { data: any[]; config: ChartProvider<string, number> } = {
+    data: [{ count_2xx: 110, count_4xx: 160, count_5xx: 80 }],
     config: {
       series: [
-        { data: { x: values('2xx'), y: field('count_2xx') }, name: 'Nombre d\'appels' },
-        { data: { x: values('4xx'), y: field('count_4xx') }, name: 'Nombre d\'appels' },
-        { data: { x: values('5xx'), y: field('count_5xx') }, name: 'Nombre d\'appels' }
+        {
+          data: { x: values('2xx'), y: field('count_2xx') },
+          name: "Nombre d'appels",
+        },
+        {
+          data: { x: values('4xx'), y: field('count_4xx') },
+          name: "Nombre d'appels",
+        },
+        {
+          data: { x: values('5xx'), y: field('count_5xx') },
+          name: "Nombre d'appels",
+        },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  barExample2: { data: any[], config: ChartProvider<string, number> } = {
+  barExample2: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 110, field: '2xx' },
       { count: 160, field: '4xx' },
-      { count: 80, field: '5xx' }
+      { count: 80, field: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: 'Nombre d\'appels' }
+        {
+          data: { x: field('field'), y: field('count') },
+          name: "Nombre d'appels",
+        },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  barExample3: { data: any[], config: ChartProvider<string, number> } = {
+  barExample3: { data: any[]; config: ChartProvider<string, number> } = {
     data: [],
     config: {
       series: [
         { data: { x: values('2xx'), y: values(110) } },
         { data: { x: values('4xx'), y: values(160) } },
-        { data: { x: values('5xx'), y: values(80) } }
+        { data: { x: values('5xx'), y: values(80) } },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  barExample4: { data: any[], config: ChartProvider<string, number> } = {
+  barExample4: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 80, field: 'Api 1', subField: '2xx' },
       { count: 20, field: 'Api 2', subField: '2xx' },
@@ -197,17 +245,19 @@ export class AppComponent {
       { count: 50, field: 'Api 3', subField: '4xx' },
       { count: 10, field: 'Api 1', subField: '5xx' },
       { count: 20, field: 'Api 2', subField: '5xx' },
-      { count: 50, field: 'Api 3', subField: '5xx' }
+      { count: 50, field: 'Api 3', subField: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: joinFields('_', 'field', 'subField'), y: field('count') } }
+        {
+          data: { x: joinFields('_', 'field', 'subField'), y: field('count') },
+        },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  barExample5: { data: any[], config: ChartProvider<string, number> } = {
+  barExample5: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 80, field: 'Api 1', subField: '2xx' },
       { count: 20, field: 'Api 2', subField: '2xx' },
@@ -217,84 +267,87 @@ export class AppComponent {
       { count: 50, field: 'Api 3', subField: '4xx' },
       { count: 10, field: 'Api 1', subField: '5xx' },
       { count: 20, field: 'Api 2', subField: '5xx' },
-      { count: 50, field: 'Api 3', subField: '5xx' }
+      { count: 50, field: 'Api 3', subField: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: field('subField') }
-      ],
-      height: 250
-    }
-  };
-
-  barExample6: { data: any[], config: ChartProvider<string, number> } = {
-    data: [
-      { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
-      { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
-    ],
-    config: {
-      series: [
-        { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
-        { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
-      ],
-      height: 250
-    }
-  };
-
-  barExample7: { data: any[], config: ChartProvider<string, number> } = {
-    data: [
-      { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
-      { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
-    ],
-    config: {
-      series: [
-        { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
-        { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        {
+          data: { x: field('field'), y: field('count') },
+          name: field('subField'),
+        },
       ],
       height: 250,
-      xorder: 'asc'
-    }
+    },
   };
 
-  barExample8: { data: any[], config: ChartProvider<string, number> } = {
+  barExample6: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
       height: 250,
-      xorder: 'desc'
-    }
+    },
   };
 
-  barExample9: { data: any[], config: ChartProvider<string, number> } = {
+  barExample7: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
       height: 250,
-      continue: true
-    }
+      xorder: 'asc',
+    },
   };
 
-  barExample10: { data: any[], config: ChartProvider<XaxisType, number> } = {
+  barExample8: { data: any[]; config: ChartProvider<string, number> } = {
+    data: [
+      { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
+      { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
+    ],
+    config: {
+      series: [
+        { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
+        { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
+      ],
+      height: 250,
+      xorder: 'desc',
+    },
+  };
+
+  barExample9: { data: any[]; config: ChartProvider<string, number> } = {
+    data: [
+      { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
+      { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
+    ],
+    config: {
+      series: [
+        { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
+        { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
+      ],
+      height: 250,
+      continue: true,
+    },
+  };
+
+  barExample10: { data: any[]; config: ChartProvider<XaxisType, number> } = {
     data: [
       { day: '1', status: 200, count: 14, group: '2xx' },
       { day: '1', status: 202, count: 5, group: '2xx' },
@@ -305,26 +358,30 @@ export class AppComponent {
       { day: '3', status: 202, count: 15, group: '2xx' },
       { day: '3', status: 400, count: 7, group: '4xx' },
       { day: '3', status: 404, count: 9, group: '4xx' },
-      { day: '3', status: 500, count: 12, group: '5xx' }
+      { day: '3', status: 500, count: 12, group: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: field('day'), y: field('count') }, name: (o, i) => `st-${o['status']}`, stack: field('group') },
+        {
+          data: { x: field('day'), y: field('count') },
+          name: (o, i) => `st-${o['status']}`,
+          stack: field('group'),
+        },
       ],
       height: 250,
-      stacked: true
-    }
+      stacked: true,
+    },
   };
 
-  funnelExample: { data: any[], config: ChartProvider<XaxisType, number> } = {
+  funnelExample: { data: any[]; config: ChartProvider<XaxisType, number> } = {
     data: [
       { count: 30, field: 'v1' },
       { count: 90, field: 'v2' },
-      { count: 60, field: 'v3' }
+      { count: 60, field: 'v3' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: 'test' }
+        { data: { x: field('field'), y: field('count') }, name: 'test' },
       ],
       height: 250,
       options: {
@@ -333,55 +390,65 @@ export class AppComponent {
             borderRadius: 0,
             horizontal: true,
             distributed: true,
-            barHeight: "80%",
-            isFunnel: true
-          }
-        }
-      }
-    }
-  }
-
-  lineExample: { data: any[], config: ChartProvider<string, number> } = {
-    data: [
-      { count_2xx: 110, count_4xx: 160, count_5xx: 80 }
-    ],
-    config: {
-      series: [
-        { data: { x: values('2xx'), y: field('count_2xx') }, name: 'Nombre d\'appels' },
-        { data: { x: values('4xx'), y: field('count_4xx') }, name: 'Nombre d\'appels' },
-        { data: { x: values('5xx'), y: field('count_5xx') }, name: 'Nombre d\'appels' }
-      ],
-      height: 250
-    }
+            barHeight: '80%',
+            isFunnel: true,
+          },
+        },
+      },
+    },
   };
 
-  lineExample2: { data: any[], config: ChartProvider<string, number> } = {
+  lineExample: { data: any[]; config: ChartProvider<string, number> } = {
+    data: [{ count_2xx: 110, count_4xx: 160, count_5xx: 80 }],
+    config: {
+      series: [
+        {
+          data: { x: values('2xx'), y: field('count_2xx') },
+          name: "Nombre d'appels",
+        },
+        {
+          data: { x: values('4xx'), y: field('count_4xx') },
+          name: "Nombre d'appels",
+        },
+        {
+          data: { x: values('5xx'), y: field('count_5xx') },
+          name: "Nombre d'appels",
+        },
+      ],
+      height: 250,
+    },
+  };
+
+  lineExample2: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 110, field: '2xx' },
       { count: 160, field: '4xx' },
-      { count: 80, field: '5xx' }
+      { count: 80, field: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: 'Nombre d\'appels' }
+        {
+          data: { x: field('field'), y: field('count') },
+          name: "Nombre d'appels",
+        },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  lineExample3: { data: any[], config: ChartProvider<string, number> } = {
+  lineExample3: { data: any[]; config: ChartProvider<string, number> } = {
     data: [],
     config: {
       series: [
         { data: { x: values('2xx'), y: values(110) } },
         { data: { x: values('4xx'), y: values(160) } },
-        { data: { x: values('5xx'), y: values(80) } }
+        { data: { x: values('5xx'), y: values(80) } },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  lineExample4: { data: any[], config: ChartProvider<string, number> } = {
+  lineExample4: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 80, field: 'Api 1', subField: '2xx' },
       { count: 20, field: 'Api 2', subField: '2xx' },
@@ -391,17 +458,19 @@ export class AppComponent {
       { count: 50, field: 'Api 3', subField: '4xx' },
       { count: 10, field: 'Api 1', subField: '5xx' },
       { count: 20, field: 'Api 2', subField: '5xx' },
-      { count: 50, field: 'Api 3', subField: '5xx' }
+      { count: 50, field: 'Api 3', subField: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: joinFields('_', 'field', 'subField'), y: field('count') } }
+        {
+          data: { x: joinFields('_', 'field', 'subField'), y: field('count') },
+        },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  lineExample5: { data: any[], config: ChartProvider<string, number> } = {
+  lineExample5: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count: 80, field: 'Api 1', subField: '2xx' },
       { count: 20, field: 'Api 2', subField: '2xx' },
@@ -411,105 +480,110 @@ export class AppComponent {
       { count: 50, field: 'Api 3', subField: '4xx' },
       { count: 10, field: 'Api 1', subField: '5xx' },
       { count: 20, field: 'Api 2', subField: '5xx' },
-      { count: 50, field: 'Api 3', subField: '5xx' }
+      { count: 50, field: 'Api 3', subField: '5xx' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: field('subField') }
+        {
+          data: { x: field('field'), y: field('count') },
+          name: field('subField'),
+        },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  lineExample6: { data: any[], config: ChartProvider<string, number> } = {
+  lineExample6: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
-      height: 250
-    }
+      height: 250,
+    },
   };
 
-  lineExample7: { data: any[], config: ChartProvider<string, number> } = {
+  lineExample7: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
       height: 250,
       stacked: true,
-      xorder: 'asc'
-    }
+      xorder: 'asc',
+    },
   };
 
-  lineExample8: { data: any[], config: ChartProvider<string, number> } = {
+  lineExample8: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
       height: 250,
-      xorder: 'desc'
-    }
+      xorder: 'desc',
+    },
   };
 
-  lineExample9: { data: any[], config: ChartProvider<string, number> } = {
+  lineExample9: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         { data: { x: field('field'), y: field('count_2xx') }, name: '2xx' },
         { data: { x: field('field'), y: field('count_4xx') }, name: '4xx' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' }
+        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx' },
       ],
       height: 250,
-      continue: true
-    }
+      continue: true,
+    },
   };
 
-  treemapExample: { data: any[], config: ChartProvider<XaxisType, YaxisType> } = {
-    data: [
-      { count: 10, field: 'ABC' },
-      { count: 30, field: 'DEF' },
-      { count: 20, field: 'XYZ' },
-      { count: 60, field: 'ABCD' },
-      { count: 10, field: 'DEFG' },
-      { count: 31, field: 'WXYZ' },
-      { count: 70, field: 'PQR' },
-      { count: 30, field: 'MNO' },
-      { count: 44, field: 'CDE' }
-    ],
-    config: {
-      series: [
-        { data: { x: field('field'), y: field('count') } }
+  treemapExample: { data: any[]; config: ChartProvider<XaxisType, YaxisType> } =
+    {
+      data: [
+        { count: 10, field: 'ABC' },
+        { count: 30, field: 'DEF' },
+        { count: 20, field: 'XYZ' },
+        { count: 60, field: 'ABCD' },
+        { count: 10, field: 'DEFG' },
+        { count: 31, field: 'WXYZ' },
+        { count: 70, field: 'PQR' },
+        { count: 30, field: 'MNO' },
+        { count: 44, field: 'CDE' },
       ],
-      height: 250
-    }
-  }
+      config: {
+        series: [{ data: { x: field('field'), y: field('count') } }],
+        height: 250,
+      },
+    };
 
-  treemapExample2: { data: any[], config: ChartProvider<XaxisType, YaxisType> } = {
+  treemapExample2: {
+    data: any[];
+    config: ChartProvider<XaxisType, YaxisType>;
+  } = {
     data: [
       { count: 10, field: 'ABC', categ: 'Desktops' },
       { count: 30, field: 'DEF', categ: 'Desktops' },
@@ -519,17 +593,23 @@ export class AppComponent {
       { count: 31, field: 'WXYZ', categ: 'Mobile' },
       { count: 70, field: 'PQR', categ: 'Mobile' },
       { count: 30, field: 'MNO', categ: 'Mobile' },
-      { count: 44, field: 'CDE', categ: 'Mobile' }
+      { count: 44, field: 'CDE', categ: 'Mobile' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: field('categ') }
+        {
+          data: { x: field('field'), y: field('count') },
+          name: field('categ'),
+        },
       ],
-      height: 250
-    }
-  }
+      height: 250,
+    },
+  };
 
-  treemapExample3: { data: any[], config: ChartProvider<XaxisType, YaxisType> } = {
+  treemapExample3: {
+    data: any[];
+    config: ChartProvider<XaxisType, YaxisType>;
+  } = {
     data: [
       { count: 10, field: 'ABC', categ: 'Desktops' },
       { count: 30, field: 'DEF', categ: 'Desktops' },
@@ -539,89 +619,115 @@ export class AppComponent {
       { count: 31, field: 'WXYZ', categ: 'Mobile' },
       { count: 70, field: 'PQR', categ: 'Mobile' },
       { count: 30, field: 'MNO', categ: 'Mobile' },
-      { count: 44, field: 'CDE', categ: 'Mobile' }
+      { count: 44, field: 'CDE', categ: 'Mobile' },
     ],
     config: {
       series: [
-        { data: { x: field('field'), y: field('count') }, name: field('categ') }
+        {
+          data: { x: field('field'), y: field('count') },
+          name: field('categ'),
+        },
       ],
       height: 250,
-      pivot: true
-    }
-  }
+      pivot: true,
+    },
+  };
 
-  heatmapExample: { data: any[], config: ChartProvider<XaxisType, YaxisType> } = {
-    data: [
-      { count: 10, field: 'ABC', categ: 'Desktops' },
-      { count: 30, field: 'DEF', categ: 'Desktops' },
-      { count: 20, field: 'XYZ', categ: 'Desktops' },
-      { count: 60, field: 'ABC', categ: 'Mobile' },
-      { count: 10, field: 'DEF', categ: 'Mobile' },
-      { count: 31, field: 'XYZ', categ: 'Mobile' },
-    ],
-    config: {
-      series: [
-        { data: { x: field('field'), y: field('count') }, name: field('categ') }
+  heatmapExample: { data: any[]; config: ChartProvider<XaxisType, YaxisType> } =
+    {
+      data: [
+        { count: 10, field: 'ABC', categ: 'Desktops' },
+        { count: 30, field: 'DEF', categ: 'Desktops' },
+        { count: 20, field: 'XYZ', categ: 'Desktops' },
+        { count: 60, field: 'ABC', categ: 'Mobile' },
+        { count: 10, field: 'DEF', categ: 'Mobile' },
+        { count: 31, field: 'XYZ', categ: 'Mobile' },
       ],
-      height: 250
-    }
-  }
+      config: {
+        series: [
+          {
+            data: { x: field('field'), y: field('count') },
+            name: field('categ'),
+          },
+        ],
+        height: 250,
+      },
+    };
 
-  rangeExample: { data: any[], config: ChartProvider<XaxisType, number[]> } = {
+  rangeExample: { data: any[]; config: ChartProvider<XaxisType, number[]> } = {
     data: [
       { min: 10, max: 30, field: '2020' },
       { min: 20, max: 25, field: '2021' },
       { min: 15, max: 50, field: '2022' },
       { min: 30, max: 50, field: '2023' },
-      { min: 25, max: 30, field: '2024' }
+      { min: 25, max: 30, field: '2024' },
     ],
     config: {
-      series: [
-        { data: { x: field('field'), y: rangeFields('min', 'max') } }
-      ],
-      height: 250
-    }
+      series: [{ data: { x: field('field'), y: rangeFields('min', 'max') } }],
+      height: 250,
+    },
   };
 
-  comboExample: { data: any[], config: ChartProvider<string, number> } = {
+  comboExample: { data: any[]; config: ChartProvider<string, number> } = {
     data: [
       { count_2xx: 80, count_4xx: 50, count_5xx: 10, field: 'Api 1' },
       { count_2xx: 20, count_4xx: 60, count_5xx: 20, field: 'Api 2' },
-      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' }
+      { count_2xx: 10, count_4xx: 50, count_5xx: 50, field: 'Api 3' },
     ],
     config: {
       series: [
         {
           data: {
-            x: field('field'), y: combineFields((args) => args.reduce((acc, o) => {
-              acc += o;
-              return acc;
-            }), ['count_2xx', 'count_4xx', 'count_5xx'])
-          }, name: 'Nombre d\'appels', type: 'column'
+            x: field('field'),
+            y: combineFields(
+              (args) =>
+                args.reduce((acc, o) => {
+                  acc += o;
+                  return acc;
+                }),
+              ['count_2xx', 'count_4xx', 'count_5xx']
+            ),
+          },
+          name: "Nombre d'appels",
+          type: 'column',
         },
-        { data: { x: field('field'), y: field('count_2xx') }, name: '2xx', type: 'line' },
-        { data: { x: field('field'), y: field('count_4xx') }, name: '4xx', type: 'line' },
-        { data: { x: field('field'), y: field('count_5xx') }, name: '5xx', type: 'line' }
+        {
+          data: { x: field('field'), y: field('count_2xx') },
+          name: '2xx',
+          type: 'line',
+        },
+        {
+          data: { x: field('field'), y: field('count_4xx') },
+          name: '4xx',
+          type: 'line',
+        },
+        {
+          data: { x: field('field'), y: field('count_5xx') },
+          name: '5xx',
+          type: 'line',
+        },
       ],
       height: 250,
       options: {
         dataLabels: {
           enabled: true,
-          enabledOnSeries: [1, 2, 3]
+          enabledOnSeries: [1, 2, 3],
         },
-        yaxis: [{
-          title: {
-            text: 'Website Blog',
+        yaxis: [
+          {
+            title: {
+              text: 'Website Blog',
+            },
           },
-
-        }, {
-          opposite: true,
-          title: {
-            text: 'Social Media'
-          }
-        }]
-      }
-    }
+          {
+            opposite: true,
+            title: {
+              text: 'Social Media',
+            },
+          },
+        ],
+      },
+    },
   };
 
   ngOnInit() {
@@ -629,6 +735,5 @@ export class AppComponent {
     console.log(test);
   }
 
-  ngAfterViewInit() {
-  }
+  ngAfterViewInit() {}
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -21,15 +21,6 @@ export class AppComponent {
     data: [{ count_2xx: 110, count_4xx: 160, count_5xx: 80 }],
     config: {
 
-      // Permettait de désactiver la toolbar pour un graph (avant c'etait par défaut à true dans les directives : show: true)
-
-      // options: {
-      //   chart: {
-      //     toolbar: { show: false },
-      //   },
-      // },
-
-      // methode simplifiée ajouter la toolbar ou non (par défaut à false comme demandé dans le fix mais voir avec Youssef. Dans les directives, si une valeur par defaut est indiquée pour showToolbar, alors show prend cette valeur sinon false)
       showToolbar: true,
 
       series: [


### PR DESCRIPTION
In this pull request : 

- Update in jquery-core/src/lib/jquery-core.models.ts to add the parameter showToolbar in a newChart as well as in interfaces so that it is typed and integrated so that graphic components can access it via config.

- Update all directives to add the showToolbar variable to _chartConfig, enabling or disabling the toolbar.

- In updateConfig() of all directives, in options -> chart -> toolbar -> show: update so that the toolbar is set by default to the value given to it in config, otherwise to false. The toolbar is therefore invisible if it is not set to true in a chart's config when it is implemented.

implementation example :

pieExample:... = {
    data: ...,
    config: {
      showToolbar: true,
... etc

Before : 

pieExample:... = {
    data: ...,
    config: {
      options: {
        chart: {
          toolbar: { 
            show: false 
          },
        },
      },
... etc