### PR TITLE
lower_angular_version_compatibility

### DIFF
--- a/projects/oneteme/jquery-apexcharts/package.json
+++ b/projects/oneteme/jquery-apexcharts/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/oneteme/jquery-charts.git"
   },
   "peerDependencies": {
-    "@angular/common": "^16.1.0",
-    "@angular/core": "^16.1.0",
+    "@angular/common": ">=16.1.0",
+    "@angular/core": ">=16.1.0",
     "apexcharts": "^3.44.0",
     "@oneteme/jquery-core": "^0.0.6"
   },

--- a/projects/oneteme/jquery-core/package.json
+++ b/projects/oneteme/jquery-core/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/oneteme/jquery-charts.git"
   },
   "peerDependencies": {
-    "@angular/common": "^16.1.0",
-    "@angular/core": "^16.1.0"
+    "@angular/common": ">=16.1.0",
+    "@angular/core": ">=16.1.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
Updated .json packages `\projects\oneteme\jquery-apexcharts\package.json` and `\projects\oneteme\jquery-core\package.json` to accept all versions of Angular equal to or higher than the jquery-chart project. Here, all versions greater than 16.1.0 will be accepted (>=16.1.0).
Previously, only minor updates and patches were accepted (^16.1.0).