### PR TITLE
Fix: Disable chart toolbar by default in chart directives and added a simple method for displaying or not the toolbar directly from a boolean in the configuration

### DIFF
--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts
@@ -27,7 +27,7 @@ export class BarChartDirective<X extends XaxisType> implements ChartView<X, numb
 
   private readonly chartInstance = signal<ApexCharts | null>(null);
 
-  private _chartConfig: ChartProvider<X, number> = {};
+  private _chartConfig: ChartProvider<X, number> = {showToolbar: false};
   private _options: any = {
     chart: {
       type: 'bar'
@@ -105,7 +105,7 @@ export class BarChartDirective<X extends XaxisType> implements ChartView<X, numb
         width: this._chartConfig.width ?? '100%',
         stacked: this._chartConfig.stacked,
         toolbar: {
-          show: true,
+          show: this._chartConfig.showToolbar ?? false,
           tools: {
             download: false,
             selection: false,

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts
@@ -26,7 +26,7 @@ export class LineChartDirective<X extends XaxisType, Y extends YaxisType> implem
 
   private readonly chartInstance = signal<ApexCharts | null>(null);
 
-  private _chartConfig: ChartProvider<X, Y> = {};
+  private _chartConfig: ChartProvider<X, Y> = {showToolbar: false};
 
   private _options: any = {
     chart: {
@@ -104,7 +104,7 @@ export class LineChartDirective<X extends XaxisType, Y extends YaxisType> implem
         width: this._chartConfig.width ?? '100%',
         stacked: this._chartConfig.stacked,
         toolbar: {
-          show: true,
+          show: this._chartConfig.showToolbar ?? false,
           tools: {
             download: false,
             selection: false,

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts
@@ -34,7 +34,7 @@ export class PieChartDirective implements ChartView<string, number>, OnChanges, 
     'radar': 'radar'
   }
 
-  private _chartConfig: ChartProvider<string, number> = {};
+  private _chartConfig: ChartProvider<string, number> = {showToolbar: false};
   private _options: any = {
     chart: {
       type: 'pie'
@@ -110,7 +110,7 @@ export class PieChartDirective implements ChartView<string, number>, OnChanges, 
         height: this._chartConfig.height ?? '100%',
         width: this._chartConfig.width ?? '100%',
         toolbar: {
-          show: true,
+          show: this._chartConfig.showToolbar ?? false,
           tools: {
             download: false,
             selection: false,

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts
@@ -27,7 +27,7 @@ export class RangeChartDirective<X extends XaxisType> implements ChartView<X, nu
 
   private readonly chartInstance = signal<ApexCharts | null>(null);
 
-  private _chartConfig: ChartProvider<X, number[]> = {};
+  private _chartConfig: ChartProvider<X, number[]> = {showToolbar: false};
 
   private _options: any = {
     chart: {
@@ -106,7 +106,7 @@ export class RangeChartDirective<X extends XaxisType> implements ChartView<X, nu
         height: this._chartConfig.height ?? '100%',
         width: this._chartConfig.width ?? '100%',
         toolbar: {
-          show: true,
+          show: this._chartConfig.showToolbar ?? false,
           tools: {
             download: false,
             selection: false,

--- a/projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts
+++ b/projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts
@@ -27,7 +27,7 @@ export class TreemapChartDirective implements ChartView<string, number>, OnChang
 
   private readonly chartInstance = signal<ApexCharts | null>(null);
 
-  private _chartConfig: ChartProvider<string, number> = {};
+  private _chartConfig: ChartProvider<string, number> = {showToolbar: false};
   private _options: any = {
     chart: {
       type: 'treemap'
@@ -104,7 +104,7 @@ export class TreemapChartDirective implements ChartView<string, number>, OnChang
         height: this._chartConfig.height ?? '100%',
         width: this._chartConfig.width ?? '100%',
         toolbar: {
-          show: true,
+          show: this._chartConfig.showToolbar ?? false,
           tools: {
             download: false,
             selection: false,

--- a/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
+++ b/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
@@ -121,7 +121,7 @@ export function buildChart<X extends XaxisType, Y extends YaxisType>(objects: an
 function newChart<X extends XaxisType, Y extends YaxisType>(provider: ChartProvider<X,Y>) : CommonChart<X,Y>{
     return Object.entries(provider)
     .filter(e=> ['series'].indexOf(e[0])<0)
-    .reduce((acc,e)=>{acc[e[0]] = e[1]; return acc;}, {series:[]})
+    .reduce((acc,e)=>{acc[e[0]] = e[1]; return acc;}, {series:[], showToolbar: provider.showToolbar})
 }
 
 function resolveDataProvider<T>(provider?: T | DataProvider<T>, defaultValue?: T): DataProvider<T> {
@@ -164,6 +164,7 @@ export interface ChartProvider<X extends XaxisType, Y extends YaxisType> { //rm 
     xorder?: Sort;
     series?: SerieProvider<X,Y>[];
     options?: any;
+    showToolbar?: boolean;
 }
 
 export interface SerieProvider<X extends XaxisType, Y extends YaxisType> { //rm SerieProvider
@@ -201,6 +202,7 @@ export interface CommonChart<X extends XaxisType, Y extends YaxisType | Coordina
     stacked?: boolean;
     xorder?: Sort;
     options?: any;
+    showToolbar?: boolean;
 }
 
 export interface CommonSerie<Y extends YaxisType | Coordinate2D> {

--- a/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
+++ b/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
@@ -202,7 +202,7 @@ export interface CommonChart<X extends XaxisType, Y extends YaxisType | Coordina
     stacked?: boolean;
     xorder?: Sort;
     options?: any;
-    // showToolbar?: boolean;
+    showToolbar?: boolean;
 }
 
 export interface CommonSerie<Y extends YaxisType | Coordinate2D> {

--- a/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
+++ b/projects/oneteme/jquery-core/src/lib/jquery-core.model.ts
@@ -121,7 +121,7 @@ export function buildChart<X extends XaxisType, Y extends YaxisType>(objects: an
 function newChart<X extends XaxisType, Y extends YaxisType>(provider: ChartProvider<X,Y>) : CommonChart<X,Y>{
     return Object.entries(provider)
     .filter(e=> ['series'].indexOf(e[0])<0)
-    .reduce((acc,e)=>{acc[e[0]] = e[1]; return acc;}, {series:[], showToolbar: provider.showToolbar})
+    .reduce((acc,e)=>{acc[e[0]] = e[1]; return acc;}, {series:[]});
 }
 
 function resolveDataProvider<T>(provider?: T | DataProvider<T>, defaultValue?: T): DataProvider<T> {
@@ -202,7 +202,7 @@ export interface CommonChart<X extends XaxisType, Y extends YaxisType | Coordina
     stacked?: boolean;
     xorder?: Sort;
     options?: any;
-    showToolbar?: boolean;
+    // showToolbar?: boolean;
 }
 
 export interface CommonSerie<Y extends YaxisType | Coordinate2D> {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,7 @@ export class AppComponent {
       { count_2xx: 110, count_4xx: 160, count_5xx: 80 }
     ],
     config: {
+      showToolbar: true,
       series: [
         { data: { x: values('2xx'), y: field('count_2xx') }, name: 'Mapper 1', color: '#2E93fA' },
         { data: { x: values('4xx'), y: field('count_4xx') }, name: 'Mapper 2', color: '#66DA26' },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,7 +12,7 @@ export class AppComponent {
       { count_2xx: 110, count_4xx: 160, count_5xx: 80 }
     ],
     config: {
-      showToolbar: true,
+      showToolbar: true, // for testing
       series: [
         { data: { x: values('2xx'), y: field('count_2xx') }, name: 'Mapper 1', color: '#2E93fA' },
         { data: { x: values('4xx'), y: field('count_4xx') }, name: 'Mapper 2', color: '#66DA26' },


### PR DESCRIPTION
This pull request introduces a new `showToolbar` configuration option across multiple chart directives to control the visibility of the toolbar in charts. The key changes include updates to the `ChartProvider` interface, modifications to various chart directive classes, and an example usage in the `AppComponent`.

### Chart Configuration Enhancements:

* [`projects/oneteme/jquery-core/src/lib/jquery-core.model.ts`](diffhunk://#diff-090a3e2804499e8ae54138ec741916c96e509917bd2a4a0907aa08b4105a1fa2L124-R124): Added `showToolbar` property to the `ChartProvider` and `CommonChart` interfaces to allow configuration of toolbar visibility. Updated the `newChart` function to include `showToolbar` in the default chart configuration. [[1]](diffhunk://#diff-090a3e2804499e8ae54138ec741916c96e509917bd2a4a0907aa08b4105a1fa2L124-R124) [[2]](diffhunk://#diff-090a3e2804499e8ae54138ec741916c96e509917bd2a4a0907aa08b4105a1fa2R167) [[3]](diffhunk://#diff-090a3e2804499e8ae54138ec741916c96e509917bd2a4a0907aa08b4105a1fa2R205)

### Directive Updates:

* [`projects/oneteme/jquery-apexcharts/src/lib/directive/bar-chart.directive.ts`](diffhunk://#diff-0f1046564ebec4a6a19bd242a66d2f6f785e2b1dbea651def795ce6d00c58eb1L30-R30): Set default `showToolbar` to `false` in `_chartConfig` and updated toolbar visibility logic in the chart options. [[1]](diffhunk://#diff-0f1046564ebec4a6a19bd242a66d2f6f785e2b1dbea651def795ce6d00c58eb1L30-R30) [[2]](diffhunk://#diff-0f1046564ebec4a6a19bd242a66d2f6f785e2b1dbea651def795ce6d00c58eb1L108-R108)
* [`projects/oneteme/jquery-apexcharts/src/lib/directive/line-chart.directive.ts`](diffhunk://#diff-b43c7f42b6089c244c37b1e74768cac135260c6ab29c62d8004cd55f50b52e8bL29-R29): Set default `showToolbar` to `false` in `_chartConfig` and updated toolbar visibility logic in the chart options. [[1]](diffhunk://#diff-b43c7f42b6089c244c37b1e74768cac135260c6ab29c62d8004cd55f50b52e8bL29-R29) [[2]](diffhunk://#diff-b43c7f42b6089c244c37b1e74768cac135260c6ab29c62d8004cd55f50b52e8bL107-R107)
* [`projects/oneteme/jquery-apexcharts/src/lib/directive/pie-chart.directive.ts`](diffhunk://#diff-a73c261cab8eeda72180e76ccd9ba196a4fa759c95187748f4a9c31e22611609L37-R37): Set default `showToolbar` to `false` in `_chartConfig` and updated toolbar visibility logic in the chart options. [[1]](diffhunk://#diff-a73c261cab8eeda72180e76ccd9ba196a4fa759c95187748f4a9c31e22611609L37-R37) [[2]](diffhunk://#diff-a73c261cab8eeda72180e76ccd9ba196a4fa759c95187748f4a9c31e22611609L113-R113)
* [`projects/oneteme/jquery-apexcharts/src/lib/directive/range-chart.directive.ts`](diffhunk://#diff-041cdcb80a4530c24d5a8c52f85176a2ec9081c646d2f89bc9639e9ee3fa9023L30-R30): Set default `showToolbar` to `false` in `_chartConfig` and updated toolbar visibility logic in the chart options. [[1]](diffhunk://#diff-041cdcb80a4530c24d5a8c52f85176a2ec9081c646d2f89bc9639e9ee3fa9023L30-R30) [[2]](diffhunk://#diff-041cdcb80a4530c24d5a8c52f85176a2ec9081c646d2f89bc9639e9ee3fa9023L109-R109)
* [`projects/oneteme/jquery-apexcharts/src/lib/directive/treemap-chart.directive.ts`](diffhunk://#diff-f29efa75b3271f97ac94987cbab30316b12031b9bcb5a0bf5b030aa87c4ca866L30-R30): Set default `showToolbar` to `false` in `_chartConfig` and updated toolbar visibility logic in the chart options. [[1]](diffhunk://#diff-f29efa75b3271f97ac94987cbab30316b12031b9bcb5a0bf5b030aa87c4ca866L30-R30) [[2]](diffhunk://#diff-f29efa75b3271f97ac94987cbab30316b12031b9bcb5a0bf5b030aa87c4ca866L107-R107)

### Example Usage:

* [`src/app/app.component.ts`](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deR15): Demonstrated the use of `showToolbar` configuration option in the chart configuration.