### PR TITLE
version 0.0.15, url demo fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         node-version: 20
     - uses: oneteme/automation-scripts/.github/actions/npm-build-project@main
       with:
-        base-href: ''
+        base-href: '/jquery-charts/'
     - uses: oneteme/automation-scripts/.github/actions/npm-github-pages@main
       with:
         project: 'jquery-charts'

--- a/angular.json
+++ b/angular.json
@@ -52,7 +52,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumError": "8kb"
                 }
               ],
               "outputHashing": "all"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-charts",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "jquery charts project",
   "private": false,
   "homepage": "https://github.com/oneteme/jquery-charts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-charts",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "jquery charts project",
   "private": false,
   "homepage": "https://github.com/oneteme/jquery-charts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-charts",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "jquery charts project",
   "private": false,
   "homepage": "https://github.com/oneteme/jquery-charts",

--- a/projects/oneteme/jquery-apexcharts/package.json
+++ b/projects/oneteme/jquery-apexcharts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-apexcharts",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "jquery apexcharts lib",
   "homepage": "https://github.com/oneteme/jquery-charts",
   "bugs": "https://github.com/oneteme/jquery-charts/issues",
@@ -12,7 +12,7 @@
     "@angular/common": ">=16.1.0",
     "@angular/core": ">=16.1.0",
     "apexcharts": "^3.44.0",
-    "@oneteme/jquery-core": "^0.0.14"
+    "@oneteme/jquery-core": "^0.0.15"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/oneteme/jquery-apexcharts/package.json
+++ b/projects/oneteme/jquery-apexcharts/package.json
@@ -12,7 +12,7 @@
     "@angular/common": ">=16.1.0",
     "@angular/core": ">=16.1.0",
     "apexcharts": "^3.44.0",
-    "@oneteme/jquery-core": "^0.0.13"
+    "@oneteme/jquery-core": "^0.0.15"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/oneteme/jquery-apexcharts/package.json
+++ b/projects/oneteme/jquery-apexcharts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-apexcharts",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "jquery apexcharts lib",
   "homepage": "https://github.com/oneteme/jquery-charts",
   "bugs": "https://github.com/oneteme/jquery-charts/issues",
@@ -12,7 +12,7 @@
     "@angular/common": ">=16.1.0",
     "@angular/core": ">=16.1.0",
     "apexcharts": "^3.44.0",
-    "@oneteme/jquery-core": "^0.0.13"
+    "@oneteme/jquery-core": "^0.0.14"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/oneteme/jquery-apexcharts/package.json
+++ b/projects/oneteme/jquery-apexcharts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-apexcharts",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "jquery apexcharts lib",
   "homepage": "https://github.com/oneteme/jquery-charts",
   "bugs": "https://github.com/oneteme/jquery-charts/issues",
@@ -12,7 +12,7 @@
     "@angular/common": ">=16.1.0",
     "@angular/core": ">=16.1.0",
     "apexcharts": "^3.44.0",
-    "@oneteme/jquery-core": "^0.0.11"
+    "@oneteme/jquery-core": "^0.0.12"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/oneteme/jquery-core/package.json
+++ b/projects/oneteme/jquery-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-core",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "jquery core lib",
   "homepage": "https://github.com/oneteme/jquery-charts",
   "bugs": "https://github.com/oneteme/jquery-charts/issues",

--- a/projects/oneteme/jquery-core/package.json
+++ b/projects/oneteme/jquery-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-core",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "jquery core lib",
   "homepage": "https://github.com/oneteme/jquery-charts",
   "bugs": "https://github.com/oneteme/jquery-charts/issues",

--- a/projects/oneteme/jquery-core/package.json
+++ b/projects/oneteme/jquery-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-core",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "jquery core lib",
   "homepage": "https://github.com/oneteme/jquery-charts",
   "bugs": "https://github.com/oneteme/jquery-charts/issues",


### PR DESCRIPTION
fix the url for the demo github page:
back to “/jquery-charts/” which creates a duplicate url, but at least it works.

note: 
- putting nothing in creates a 404 error
-  putting only a “/” displays nothing

see npm-github-pages action code in the oneteme/automation-scripts repo to potentially fix the duplicate url

