### PR TITLE
update fix pan icon on apexcharts original toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-charts",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "jquery charts project",
   "private": false,
   "homepage": "https://github.com/oneteme/jquery-charts",

--- a/projects/oneteme/jquery-apexcharts/package.json
+++ b/projects/oneteme/jquery-apexcharts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-apexcharts",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "jquery apexcharts lib",
   "homepage": "https://github.com/oneteme/jquery-charts",
   "bugs": "https://github.com/oneteme/jquery-charts/issues",


### PR DESCRIPTION
Currently, when multiple charts are displayed on the same page, when the “pan” tool is used on several of them, the pan icon is only visible on the first chart and the other pan icons disappear (duplicate ID).