### PR TITLE
Jquery table/horizontal scroll default groupby export prefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-charts",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "jquery charts project",
   "private": false,
   "homepage": "https://github.com/oneteme/jquery-charts",

--- a/projects/oneteme/jquery-table/package.json
+++ b/projects/oneteme/jquery-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneteme/jquery-table",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "jquery table lib",
   "homepage": "https://github.com/oneteme/jquery-charts",
   "bugs": "https://github.com/oneteme/jquery-charts/issues",

--- a/projects/oneteme/jquery-table/src/lib/component/table.component.scss
+++ b/projects/oneteme/jquery-table/src/lib/component/table.component.scss
@@ -416,9 +416,12 @@
 }
 
 // Les th doivent être en position relative pour que la poignée s'y positionne
-// overflow visible pour que la poignée ne soit pas rognée
+// overflow visible uniquement en mode édition / drag-drop (sinon le header déborde du scroll container)
 :host ::ng-deep th.mat-mdc-header-cell {
   position: relative;
+}
+
+:host ::ng-deep th.mat-mdc-header-cell.drag-enabled {
   overflow: visible !important;
 }
 

--- a/projects/oneteme/jquery-table/src/lib/component/table.component.ts
+++ b/projects/oneteme/jquery-table/src/lib/component/table.component.ts
@@ -10,7 +10,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { Subject, takeUntil } from 'rxjs';
-import { TableColumnProvider, TableProvider, TableViewConfig } from '../jquery-table.model';
+import { TableColumnProvider, TableExportConfig, TablePreferencesConfig, TableProvider, TableViewConfig } from '../jquery-table.model';
 import { JqtI18n, JQT_I18N, JQT_I18N_DEFAULTS } from '../jqt-i18n.token';
 import { JqtCellDefDirective } from '../directive/jqt-cell-def.directive';
 import { SliceConfig } from './slice-panel/slice-panel.model';
@@ -221,6 +221,8 @@ export class TableComponent<T = any> implements OnChanges, AfterContentInit, Aft
   /** Vrai si une configuration est sauvegardée pour ce tableau. */
   _hasSavedConfig = false;
   private _preferencesManager: TablePreferencesManager | null = null;
+  /** true une fois que le group-by par défaut a été initialisé (évite de reconfigurer GroupByManager à chaque changement de données). */
+  private _defaultGroupByApplied = false;
   private _resizeState: { key: string; startX: number; startWidth: number } | null = null;
   /** Dynamic slice keys à restaurer après ngAfterViewInit (slicePanelRef pas encore dispo). */
   private _pendingDynamicSliceKeys: string[] | null = null;
@@ -725,14 +727,18 @@ export class TableComponent<T = any> implements OnChanges, AfterContentInit, Aft
    * Retourne null si aucune colonne n'a de largeur définie (le tableau remplit alors 100% du conteneur).
    * Seules les valeurs explicitement en `px` sont sommables ; les pourcentages ou autres unités sont ignorés. */
   get tableMinWidth(): string | null {
-    const hasSomeExplicitWidth = this.activeColumns.some(c => c.width);
+    const hasResized = Object.keys(this._columnWidths).length > 0;
+    const hasSomeExplicitWidth = hasResized || this.activeColumns.some(c => c.width);
     if (!hasSomeExplicitWidth) return null;
     let sum = 0;
     for (const col of this.activeColumns) {
-      if (col.width) {
+      if (this._columnWidths[col.key] != null) {
+        sum += this._columnWidths[col.key];
+      } else if (col.width) {
         const isPx = col.width.trim().toLowerCase().endsWith('px');
         const px = Number.parseFloat(col.width);
         if (isPx && !Number.isNaN(px)) { sum += px; }
+        else { sum += 150; }
       } else {
         sum += 120; // largeur minimale estimée pour une colonne sans largeur explicite
       }
@@ -829,6 +835,19 @@ export class TableComponent<T = any> implements OnChanges, AfterContentInit, Aft
     const th = (event.target as HTMLElement).closest('th') as HTMLElement | null;
     if (!th) return;
 
+    const scrollEl = this.tableBodyScrollRef?.nativeElement;
+    if (scrollEl) {
+      const allTh = scrollEl.querySelectorAll<HTMLElement>('th.mat-mdc-header-cell');
+      allTh.forEach(thEl => {
+        const key = thEl.getAttribute('mat-column-header') || thEl.getAttribute('mat-sort-header') || '';
+        const colClass = Array.from(thEl.classList).find(c => c.startsWith('mat-column-'));
+        const colKey = colClass ? colClass.replace('mat-column-', '') : null;
+        if (colKey && this._columnWidths[colKey] == null) {
+          this._columnWidths = { ...this._columnWidths, [colKey]: thEl.offsetWidth };
+        }
+      });
+    }
+
     this._resizeState = { key: columnKey, startX: event.clientX, startWidth: th.offsetWidth };
 
     const onMove = (e: MouseEvent) => {
@@ -907,6 +926,7 @@ export class TableComponent<T = any> implements OnChanges, AfterContentInit, Aft
 
     // Colonnes et groupBy : reset via la facade (retire les optionnelles, remet l'ordre config)
     this._view.resetToDefaults();
+    this._defaultGroupByApplied = false;
 
     // Dynamic slices : les retirer du slice panel avec la liste capturée avant le reset
     dynamicSlicesToRemove.forEach(col => {
@@ -1043,7 +1063,15 @@ export class TableComponent<T = any> implements OnChanges, AfterContentInit, Aft
       config: this.resolvedConfig.view,
       columns: this.resolvedConfig.columns ?? [],
       sliceConfigs: this.resolvedConfig.slices ?? [],
+      defaultGroupBy: this.resolvedConfig.defaultGroupBy,
     });
+
+    if (!pendingPrefs && !this._defaultGroupByApplied && !this._view.groupBy.userCustomized && this._view.groupBy.activeKey != null) {
+      this._defaultGroupByApplied = true;
+      this._groupBy.setDefaultCollapsed(true);
+      this._groupBy.reset();
+      this._groupBy.groupPageSize = this.resolveDefaultGroupPageSize();
+    }
 
     // Synchronise la propriété stable (évite NG0100 — la facade est source de vérité)
     this.activeColumns = this._view.fields.activeColumns;
@@ -1223,13 +1251,38 @@ export class TableComponent<T = any> implements OnChanges, AfterContentInit, Aft
     // Mode HTML : [view] prend le dessus sur config.view si fourni (Phase 3).
     const view = this.view ?? config.view;
 
+    const autoTableId = config.preferences?.tableId || TableComponent._hashColumns((columns || []).map(c => c.key));
+    const exportConfig: TableExportConfig<T> = {
+      enabled: true,
+      filename: autoTableId,
+      ...config.export,
+    };
+
+    const prefsConfig: TablePreferencesConfig = {
+      enabled: true,
+      tableId: autoTableId,
+      ...config.preferences,
+    };
+
     return {
       ...config,
       columns,
       view,
       slices: config.slices || [],
       enableSliceToggle: config.enableSliceToggle ?? true,
+      export: exportConfig,
+      preferences: prefsConfig,
     };
+  }
+
+  private static _hashColumns(keys: string[]): string {
+    const str = keys.join('|');
+    let h = 0x811c9dc5;
+    for (let i = 0; i < str.length; i++) {
+      h ^= str.charCodeAt(i);
+      h = Math.imul(h, 0x01000193) >>> 0;
+    }
+    return h.toString(16).padStart(8, '0');
   }
 
   private resolveData(): T[] {

--- a/projects/oneteme/jquery-table/src/lib/component/view/view.facade.ts
+++ b/projects/oneteme/jquery-table/src/lib/component/view/view.facade.ts
@@ -17,6 +17,7 @@ export interface ViewFieldState {
 
 export interface ViewGroupByState {
   activeKey: string | null;
+  userCustomized: boolean;
 }
 
 export interface ViewSliceByState {
@@ -34,8 +35,8 @@ export interface ViewPanelConfig {
   /** Slices statiques */
   sliceConfigs: SliceConfig<any>[];
   /** Label utilisé quand aucun groupe / aucune slice n’est actif. Défaut : 'Aucun'. */
-  noneLabel?: string;
-}
+  noneLabel?: string;  /** Clé de colonne utilisée comme group-by par défaut au chargement. */
+  defaultGroupBy?: string | null;}
 
 // ── Facade
 
@@ -59,6 +60,7 @@ export class ViewFacade<T = any> {
 
   readonly groupBy: ViewGroupByState = {
     activeKey: null,
+    userCustomized: false,
   };
 
   readonly sliceBy: ViewSliceByState = {
@@ -152,6 +154,9 @@ export class ViewFacade<T = any> {
     this._panelConfig = panelConfig;
     this._refreshDefaultColumns();
     this._refreshDynamicSliceMeta();
+    if (!this.groupBy.userCustomized) {
+      this.groupBy.activeKey = panelConfig.defaultGroupBy ?? null;
+    }
   }
 
   // ── Actions Fields
@@ -165,11 +170,12 @@ export class ViewFacade<T = any> {
     this.fields.userCustomized = value;
   }
 
-  /** Remet la vue dans son état initial : colonnes par défaut, pas de groupBy, pas de dynamic slices. */
+  /** Remet la vue dans son état initial : colonnes par défaut, groupBy par défaut, pas de dynamic slices. */
   resetToDefaults(): void {
     this.fields.userCustomized = false;
+    this.groupBy.userCustomized = false;
     this._refreshDefaultColumns();
-    this.groupBy.activeKey = null;
+    this.groupBy.activeKey = this._panelConfig.defaultGroupBy ?? null;
     this.sliceBy.activeDynamicColumns = [];
     this._refreshDynamicSliceMeta();
   }
@@ -237,6 +243,7 @@ export class ViewFacade<T = any> {
 
   setGroupBy(key: string | null): void {
     this.groupBy.activeKey = key;
+    this.groupBy.userCustomized = true;
     this._events$.next({ type: 'groupByChanged', key });
   }
 

--- a/projects/oneteme/jquery-table/src/lib/jquery-table.model.ts
+++ b/projects/oneteme/jquery-table/src/lib/jquery-table.model.ts
@@ -87,7 +87,7 @@ export function col<T = any>(
 
 /** Configuration de l’export CSV déclenché depuis la toolbar. */
 export interface TableExportConfig<T = any> {
-  /** Affiche le bouton Export dans la toolbar. Par défaut : `false`. */
+  /** Affiche le bouton Export dans la toolbar. Par défaut : `true`. */
   enabled?: boolean;
   /** Nom du fichier généré. Par défaut : `'export.csv'`. */
   filename?: string;
@@ -109,14 +109,15 @@ export interface TableExportConfig<T = any> {
  * Chaque tableau est identifié par `tableId` (clé localStorage unique).
  */
 export interface TablePreferencesConfig {
-  /** Active la fonctionnalité. Par défaut : `false`. */
+  /** Active la fonctionnalité. Par défaut : `true`. */
   enabled?: boolean;
   /**
    * Identifiant unique du tableau, utilisé comme clé localStorage.
    * Doit être stable entre les rechargements de page.
+   * Si absent, un identifiant est dérivé automatiquement des clés de colonnes.
    * Exemple : `'user-table'`, `'invoice-list'`.
    */
-  tableId: string;
+  tableId?: string;
 }
 
 /** Snapshot de configuration persisté dans le localStorage. */
@@ -152,6 +153,8 @@ export interface TableProvider<T = any> {
   labels?: TableLabelsConfig;
   /** Tri initial appliqué au chargement. N'est pas écrasé par les changements de données. */
   defaultSort?: { active: string; direction: 'asc' | 'desc' };
+  /** Clé de colonne à utiliser comme group-by par défaut au chargement. N'est pas écrasé par les changements de données ni par un reset explicite de l'utilisateur. */
+  defaultGroupBy?: string | null;
   rowClass?: (row: T, index: number) => string | string[] | Record<string, boolean>;
   /** Callback déclenché quand l'utilisateur clique sur une ligne. Alternative au `(rowSelected)` Output. */
   onRowSelected?: (row: T, event: MouseEvent | null) => void;


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the `@oneteme/jquery-table` library, focusing on enhanced default behaviors and configurability for group-by, export, and preferences features. It also includes minor version bumps for both the main package and the table sub-package.

**Enhancements to Table Behavior and Configuration:**

*Default Group-By Improvements:*
- Added support for specifying a default group-by column via `defaultGroupBy` in both `TableProvider` and `ViewPanelConfig`. The group-by state now tracks if the user has customized it, ensuring the default is only set when appropriate. Resetting the view restores the default group-by rather than clearing it. [[1]](diffhunk://#diff-fc69cd1d5c2286e30c7c8043fc6c8bbb85ba5bdb14c21571876faebe290ef17dR156-R157) [[2]](diffhunk://#diff-7a0874fa20b4f11cf7d14ac98631b0517403699d6087bbeee41102ad64bd4227L37-R39) [[3]](diffhunk://#diff-7a0874fa20b4f11cf7d14ac98631b0517403699d6087bbeee41102ad64bd4227R20) [[4]](diffhunk://#diff-7a0874fa20b4f11cf7d14ac98631b0517403699d6087bbeee41102ad64bd4227R63) [[5]](diffhunk://#diff-7a0874fa20b4f11cf7d14ac98631b0517403699d6087bbeee41102ad64bd4227R157-R159) [[6]](diffhunk://#diff-7a0874fa20b4f11cf7d14ac98631b0517403699d6087bbeee41102ad64bd4227L168-R178) [[7]](diffhunk://#diff-7a0874fa20b4f11cf7d14ac98631b0517403699d6087bbeee41102ad64bd4227R246) [[8]](diffhunk://#diff-160fa43f1d911aa2fc5a6bd570705eb6632643c6fb392ee9946725b44ca427c5R224-R225) [[9]](diffhunk://#diff-160fa43f1d911aa2fc5a6bd570705eb6632643c6fb392ee9946725b44ca427c5R929) [[10]](diffhunk://#diff-160fa43f1d911aa2fc5a6bd570705eb6632643c6fb392ee9946725b44ca427c5R1066-R1075)

*Export and Preferences Configuration:*
- Export and preferences are now enabled by default unless explicitly disabled. If a `tableId` is not provided, an automatic stable identifier is generated from the column keys, ensuring consistent localStorage keys across reloads. [[1]](diffhunk://#diff-fc69cd1d5c2286e30c7c8043fc6c8bbb85ba5bdb14c21571876faebe290ef17dL90-R90) [[2]](diffhunk://#diff-fc69cd1d5c2286e30c7c8043fc6c8bbb85ba5bdb14c21571876faebe290ef17dL112-R120) [[3]](diffhunk://#diff-160fa43f1d911aa2fc5a6bd570705eb6632643c6fb392ee9946725b44ca427c5L13-R13) [[4]](diffhunk://#diff-160fa43f1d911aa2fc5a6bd570705eb6632643c6fb392ee9946725b44ca427c5R1254-R1287)

*Column Width and Resizing Fixes:*
- Improved column resizing logic: when a resize is initiated, the current widths of all header cells are captured if not already set, ensuring accurate width calculations. The table’s minimum width calculation now considers both explicit and user-resized widths. [[1]](diffhunk://#diff-160fa43f1d911aa2fc5a6bd570705eb6632643c6fb392ee9946725b44ca427c5L728-R741) [[2]](diffhunk://#diff-160fa43f1d911aa2fc5a6bd570705eb6632643c6fb392ee9946725b44ca427c5R838-R850)

*Styling Adjustments:*
- Updated SCSS for table headers to only allow overflow when drag-and-drop is enabled, preventing header content from overflowing the container in normal mode.

**Version Updates:**

*Version Bumps:*
- Bumped `@oneteme/jquery-charts` to version `0.0.35` and `@oneteme/jquery-table` to version `0.0.3`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-85a24e91067ea2ee874a5342299f376589ed049b930765e109ac80e73cb6bddaL3-R3)